### PR TITLE
responsive styles for `/publications` (fixes #97)

### DIFF
--- a/hugo/assets/scss/publications.scss
+++ b/hugo/assets/scss/publications.scss
@@ -57,4 +57,14 @@
             }
         }
     }
+
+    @include media-small {
+        section.publicationHighlight {
+            flex-direction: column;
+        }
+
+        ul {
+            grid-template-columns: 1fr;
+        }
+    }
 }


### PR DESCRIPTION
This PR makes the publications page responsive (by switching the grid layout to have only one column)

fixes #97