### PR TITLE
Fix link to 2021 report

### DIFF
--- a/hugo/content/research/archives/2021.md
+++ b/hugo/content/research/archives/2021.md
@@ -9,7 +9,7 @@ type: research_archives
 ---
 
 # DORA's Research Program: 2021
-In 2021, DORA did deep-dive investigations into security, reliability, documentation, and more. You can [read the 2021 report here](/pdf/state-of-devops-2021.pdf). Below are some of the analytical tools used in producing the report.
+In 2021, DORA did deep-dive investigations into security, reliability, documentation, and more. You can [read the 2021 report here](/publications/pdf/state-of-devops-2021.pdf). Below are some of the analytical tools used in producing the report.
 
 {{< comment >}}
     SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"


### PR DESCRIPTION
The [2021 research archive](https://dora.dev/research/archives/2021/) now links to the 2021 report instead of a 404.