### PR TITLE
add page indicator to nav  (Fixes #100)

### DIFF
--- a/hugo/assets/scss/nav.scss
+++ b/hugo/assets/scss/nav.scss
@@ -17,6 +17,14 @@ header {
                     color: rgb(95, 99, 104);
                     white-space:nowrap;
                     font-weight: 400;
+                    font-size:1em;
+                    line-height:1em;
+
+                    span.google-material-icons {
+                        font-size: 1em;
+                        line-height: 1em;
+                        vertical-align:middle;
+                    }
                 }
 
                 a:hover {

--- a/hugo/assets/scss/nav.scss
+++ b/hugo/assets/scss/nav.scss
@@ -16,11 +16,18 @@ header {
                     text-decoration: none;
                     color: rgb(95, 99, 104);
                     white-space:nowrap;
+                    font-weight: 400;
                 }
 
                 a:hover {
                     color: rgb(0, 0, 0);
                 }
+
+                a.active {
+                    color: black;
+                    font-weight: 600;
+                }
+
             }
         }
     }

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -22,7 +22,8 @@
 <meta name="description" content="{{ .Site.Params.Description }}">
 <meta name="keywords" content="{{ .Site.Params.Keywords }}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700|Google+Sans:100,200,300,400,500|Google+Material+Icons&amp;lang=en" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;600;700" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto:wght@100,300,400,500,700|Google+Material+Icons&amp;lang=en" rel="stylesheet">
 
 <!-- favicons -->
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/hugo/layouts/partials/header.html
+++ b/hugo/layouts/partials/header.html
@@ -8,11 +8,11 @@
             <input type="checkbox">
             <span class="menu"> <span class="hamburger"></span> </span>
             <ul>
-                <li><a href="/publications/">Publications</a></li>
-                <li><a href="/research/">Research</a></li>
+                <li><a href="/publications/" {{ if (eq .Section "publications") }}class="active"{{ end }}>Publications</a></li>
+                <li><a href="/research/" {{ if (eq .Section "research") }}class="active"{{ end }}>Research</a></li>
                 <li><a href="https://bit.ly/dora-capabilities" target="_blank">Capabilities</a></li>
-                <li><a href="/quickcheck/">Quick Check</a></li>
-                <li><a href="/resources/">Resources</a></li>
+                <li><a href="/quickcheck/" {{ if (eq .Section "quickcheck") }}class="active"{{ end }}>Quick Check</a></li>
+                <li><a href="/resources/" {{ if (eq .Section "resources") }}class="active"{{ end }}>Resources</a></li>
                 <li><a href="https://dora.community/" target="_blank">Community</a></li>
             </ul>
             <div class="page-overlay"></div>

--- a/hugo/layouts/partials/header.html
+++ b/hugo/layouts/partials/header.html
@@ -10,10 +10,10 @@
             <ul>
                 <li><a href="/publications/" {{ if (eq .Section "publications") }}class="active"{{ end }}>Publications</a></li>
                 <li><a href="/research/" {{ if (eq .Section "research") }}class="active"{{ end }}>Research</a></li>
-                <li><a href="https://bit.ly/dora-capabilities" target="_blank">Capabilities</a></li>
+                <li><a href="https://bit.ly/dora-capabilities" target="_blank">Capabilities&nbsp;&nbsp;<span class="google-material-icons">open_in_new</span></a></li>
                 <li><a href="/quickcheck/" {{ if (eq .Section "quickcheck") }}class="active"{{ end }}>Quick Check</a></li>
                 <li><a href="/resources/" {{ if (eq .Section "resources") }}class="active"{{ end }}>Resources</a></li>
-                <li><a href="https://dora.community/" target="_blank">Community</a></li>
+                <li><a href="https://dora.community/" target="_blank">Community&nbsp;&nbsp;<span class="google-material-icons">open_in_new</span></a></li>
             </ul>
             <div class="page-overlay"></div>
         </label>


### PR DESCRIPTION
This PR: 

- adds "open in new tab" icons to the Capabilities and Community links in the top menu.
  - _For "Capabilities", this is a temporary addition; that content will be migrated onto dora.dev shortly_
- adds indication of which page the user is currently on

Fixes #106 
Fixes #100 