### PR TITLE
Make capabilities index responsive  (Fixes #165)

### DIFF
--- a/hugo/assets/scss/devops-capabilities.scss
+++ b/hugo/assets/scss/devops-capabilities.scss
@@ -115,3 +115,15 @@ section.hasSidebar {
         }
     }
 }
+
+@include media-medium {
+    .capabilitiesGrid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@include media-medium {
+    .capabilitiesGrid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
This PR makes the index of the capabilities page (/devops-capabilities/) responsive, by reducing to two columns on medium-width screens, and one column on narrow screens.

Fixes #165