### PR TITLE
Close popovers on click outside or escape

### DIFF
--- a/adrs/use-alpineJS-for-light-weight-JS-framework.md
+++ b/adrs/use-alpineJS-for-light-weight-JS-framework.md
@@ -1,0 +1,50 @@
+---
+# These are optional elements. Feel free to remove any of them.
+status: proposed
+date: 2023-04-07
+deciders: davidstanke
+consulted: jesseguke
+informed:
+---
+# Use AlpineJS as a lightweight JS framework for decorating HTML elements
+
+## Context and Problem Statement
+
+Much of the DORA.dev site is static HTML and various assets/resources (i.e., PDF and images). For good UX and to move away from custom (hard to maintain) javascript, we need a lightweight javascript framework to assist in the decoration and visibility of DOM objects (e.g., modal windows)
+
+## Decision Drivers
+
+* A progressive JavaScript which is addative to the current site (e.g., does not require extensive refactoring for adoption)
+* Extensible with vanilla JavaScript
+* Support two-way binding
+* Low barrier of entry; Easy to learn
+* Do not require additional frameworks or processes required for build and development (e.g., Java, NodeJS, etc.)
+* Friendly OSS License
+
+## Considered Options
+
+* AlpineJS ([website](https://alpinejs.dev/))
+* AngularJS ([website](https://angularjs.org/))
+* React ([website](https://react.dev/))
+* Vue.js ([website](https://vuejs.org/))
+
+## Decision Outcome
+
+Chosen option: Use AlpineJS as a lightweight JS framework for decorating HTML elements because it meets the Decision drivers [above Decision Drivers](#decision-drivers). Contributors can easily contribute based on AlpineJS within just a few mins of understanding the framework. By design, the framework is limited in functionality yet has powerful features that can be embedded/removed directly/from the existing HTML and DOM objects to reduce time to value.
+
+### Consequences
+
+* Good, because the light framework makes for easy adoption and low-risk integration. If future choices move away from AlpineJS, the risk is low due to the loose coupling and may work with other frameworks.
+
+* Bad, because it is light and limited. It may not support more complex design and functional requirements. However, with a loosely coupled architecture, feature-rich solutions can be adopted as separate services/solutions. Additionally, the framework does not enforce MVVM/MVP design patterns, but at this time, with Hugo, this functionality does not appear to be needed in the JS requirements.
+
+### Other Considerations
+
+Other considerations (e.g., React, AngularJS, Vue.js)
+
+* They have solid adoption with a large, active community. However, they were not selected for the recommendation as the adoption would require a more considerable integration effort to achieve initial value, a  learning curve, or additional tooling (e.g., NodeJS and Vue.js) for development or build processes.
+
+## More Information
+
+Additional readings:
+* [State of JS] (https://2022.stateofjs.com/en-US/libraries/front-end-frameworks/)

--- a/hugo/assets/js/results_2019.js
+++ b/hugo/assets/js/results_2019.js
@@ -414,6 +414,13 @@ function createCapabilitiesTable(profile) {
         e.preventDefault();
         document.getElementById('modal').style.display='block';
         createCapabilitiesTable(userProfileAndPercentile.profile);
+
+        //Add event handler if the escape key is pressed
+        document.addEventListener("keydown", (event) => {
+          if (event.key === 'Escape') {
+            document.getElementById('modal').style.display='none';
+          }
+        });
     })
 
     document.getElementById('results').addEventListener('click', function(e) {

--- a/hugo/assets/scss/quickcheck_2019.scss
+++ b/hugo/assets/scss/quickcheck_2019.scss
@@ -2,6 +2,8 @@
 
 // survey page
 
+[x-cloak] { display: none; }
+
 .icon {
     display: inline-block;
     position: relative;

--- a/hugo/content/quickcheck/2019/results.html
+++ b/hugo/content/quickcheck/2019/results.html
@@ -43,7 +43,7 @@ type: quickcheck_2019
                 </div>
               </div>
           </div>
-          <img class="x" x-on:click="isModalOpen=false"  aria-controls="share-modal" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">
+          <img class="modal-close x" x-on:click="isModalOpen=false"  aria-controls="share-modal" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">
         </div>
     </div><!-- end share-modal -->
     </div>

--- a/hugo/content/quickcheck/2019/results.html
+++ b/hugo/content/quickcheck/2019/results.html
@@ -18,88 +18,103 @@ type: quickcheck_2019
     </aside>
     <div class="performance-graph-container">
         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="yourPerformanceMarker"></div>
-        <div id="performance-graph"></div>  
+        <div id="performance-graph"></div>
     </div>
 </section>
 <section id="results-actions">
+    <div x-data="{'isModalOpen': false}"
+    x-on:click.outside="isModalOpen = false"
+    x-on:keydown.escape.window="isModalOpen = false"
+    x-on:keydown.enter.window="isModalOpen = false">
     <h3>You're performing better than <span id="percentile">&nbsp;&nbsp;&nbsp;</span>&percnt; of 2019 <a href="https://cloud.google.com/devops/state-of-devops/" target="_blank">State&nbsp;of&nbsp;DevOps&nbsp;Survey</a> respondents.&nbsp;</h3>
     <small>Take the Quick Check from other research years: <a href="/quickcheck/?year=2019">2019</a>&nbsp;&nbsp;<a href="/quickcheck/?year=2021">2021</a>&nbsp;&nbsp;<a href="/quickcheck/">2022</a></small>
     <br><br>
-    <button class="modal-open" aria-controls="share-modal">Share results</button>
+    <button x-on:click="isModalOpen = true" aria-controls="share-modal">Share results</button>
     <a href='{{% relref "/quickcheck/" %}}'><button class="secondary">Start over</button></a>
-    <div id="share-modal"  role="dialog" aria-modal="true" aria-labelledby="share-modal-label" aria-describedby="share-modal-content">
-        <div class="wrapper">
+    <div id="share-modal" x-show="isModalOpen" x-cloak x-transition role="dialog" aria-modal="true" aria-labelledby="share-modal-label" aria-describedby="share-modal-content">
+        <div x-cloak class="wrapper" x-on:click.away="isModalOpen = false">
           <h1 id="share-modal-label" >Share your results</h1>
           <div id="share-modal-content" >
             <p >We've copied the URL to your DORA DevOps Quick Check results to your clipboard.</p>
             <p >Share via social media, email or chat.</p>
-            <div id="share-url-container">
-                <div id="share-url" contenteditable="true">
+            <div x-cloak id="share-url-container">
+                <div x-cloak id="share-url" contenteditable="true">
                   I am vertically aligned
                 </div>
               </div>
           </div>
-          <img class="modal-close x" aria-controls="share-modal" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">
+          <img class="x" x-on:click="isModalOpen=false"  aria-controls="share-modal" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">
         </div>
-      </div>
+    </div><!-- end share-modal -->
+    </div>
 </section>
 <section>
-    {{< tab_navigation 
+    {{< tab_navigation
         titles="Improvement areas,Performance comparison,Unknown performers"
-        controls="c_capabilities,c_compare,c_breakdown" 
+        controls="c_capabilities,c_compare,c_breakdown"
         classes=" , ,profile-title"
-        selected="Improvement areas" 
+        selected="Improvement areas"
         >}}
 </section>
 <section id="c_capabilities" class="tab">
-    <div id="caps_unprioritized">
-        <h2>Key DevOps capabilities for <span class="profile-title">unknown</span> performers</h2>
-        <div class="description">
-            <p >When we analyzed the responses of other <strong class="color-by-profile"><span class="profile-title">unknown</span> performers</strong>, we found that working on these three
-                capabilities had the most impact on improving their software delivery performance.</p>
-            <p><button  id="cap-click">Help me prioritize</button></p>
-            <p class="small">Rank your responses to a series of 3-12 questions for
-                each of these three capabilities, to determine how you perform and which to consider focusing on
-                first.</p>
-        </div>
-        <div id="key-capabilities">
-            <div class="capabilities-container">
-                <div class="rec">
-                    <a  id="rec-link-0"
-                        href="https://cloud.google.com/solutions/devops/devops-tech-version-control">
-                        <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-0" alt="Icon that represents this capability">
-                        <h3 id="rec-name-0">Version control</h3>
-                        Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
-                    </a>
-                </div>
-                <div class="rec">
-                    <a  id="rec-link-1"
-                        href="https://cloud.google.com/solutions/devops/devops-tech-version-control">
-                        <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-1" alt="Icon that represents this capability">
-                        <h3 id="rec-name-1">Version control</h3>
-                        Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
-                    </a>
-                </div>
-                <div class="rec">
-                    <a  id="rec-link-2"
-                        href="https://cloud.google.com/solutions/devops/devops-tech-version-control">
-                        <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-2" alt="Icon that represents this capability">
-                        <h3 id="rec-name-2">Version control</h3>
-                        Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
-                    </a>
-                </div>
+<div id="caps_unprioritized">
+    <h2>Key DevOps capabilities for <span class="profile-title">unknown</span> performers</h2>
+    <div class="description">
+        <p >When we analyzed the responses of other <strong class="color-by-profile"><span class="profile-title">unknown</span> performers</strong>, we found that working on these three
+            capabilities had the most impact on improving their software delivery performance.</p>
+        <p><button id="cap-click" x-on:click="createCapabilitiesTable">Help me prioritize</button></p>
+        <p class="small">Rank your responses to a series of 3-12 questions for
+            each of these three capabilities, to determine how you perform and which to consider focusing on
+            first.</p>
+    </div>
+    <div id="key-capabilities">
+        <div class="capabilities-container">
+            <div class="rec">
+                <a  id="rec-link-0"
+                    href="https://cloud.google.com/solutions/devops/devops-tech-version-control">
+                    <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-0" alt="Icon that represents this capability">
+                    <h3 id="rec-name-0">Version control</h3>
+                    Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
+                </a>
+            </div>
+            <div class="rec">
+                <a  id="rec-link-1"
+                    href="https://cloud.google.com/solutions/devops/devops-tech-version-control">
+                    <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-1" alt="Icon that represents this capability">
+                    <h3 id="rec-name-1">Version control</h3>
+                    Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
+                </a>
+            </div>
+            <div class="rec">
+                <a  id="rec-link-2"
+                    href="https://cloud.google.com/solutions/devops/devops-tech-version-control">
+                    <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-2" alt="Icon that represents this capability">
+                    <h3 id="rec-name-2">Version control</h3>
+                    Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
+                </a>
             </div>
         </div>
     </div>
 </div>
-<div id="caps_prioritized">
+
+<div id="caps_prioritized" >
     <h2>Key DevOps capabilities recommended for you</h2>
     <div class="recommendations">
-        <div class="header">
-            <p>Based on your performance profile, we think you should work on the three capabilities listed below. Based on your responses to the capabilities assessment, <strong>we recommend you focus on <span id="capability"></span> first.</strong> <a class="popover-more modal-open" aria-controls="capability-calc-popover" title="How was this calculated?"><span class="sr-only">How was this calculated?</span></a></p>
-            <div id="capability-calc-popover" class="popover">
-            <p>We prioritized based on your average score for each capability. You should also consider other factors, such as the effort required to implement these capabilities in your organization, and which you think will have the biggest impact on your performance.</p>
-            <img class="modal-close x" aria-controls="capability-calc-popover" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">
+        <div x-data="{'isModalOpen': false}"  >
+            <div class="header">
+                <p>Based on your performance profile, we think you should work on the three capabilities listed below. Based on your responses to the capabilities assessment, <strong>we recommend you focus on <span id="capability"></span> first.</strong>
+                <a class="popover-more modal-open" x-on:click="isModalOpen = true" aria-controls="capability-calc-popover" title="How was this calculated?"><span class="sr-only">How was this calculated?</span></a>
+
+                </p>
+                <div id="capability-calc-popover"
+                    x-show="isModalOpen" x-cloak x-transition
+                    x-on:click.outside="isModalOpen = false"
+                    x-on:keydown.escape.window="isModalOpen = false"
+                    x-on:keydown.enter.window="isModalOpen = false"
+                    role="dialog" class="popover">
+                    <p>We prioritized based on your average score for each capability. You should also consider other factors, such as the effort required to implement these capabilities in your organization, and which you think will have the biggest impact on your performance.</p>
+                    <img class="x"  x-on:click="isModalOpen = false" aria-controls="capability-calc-popover" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">
+                </div>
             </div>
         </div>
         <div class="recommendation-container top">
@@ -113,7 +128,7 @@ type: quickcheck_2019
                     <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="capability-marker-0"></div>
                     <div id="cap-graph-0" class="capability-graph"></div>
                 </div>
-            </div>    
+            </div>
         </div>
         <div class="recommendation-container">
             <div class="recommendation">
@@ -141,11 +156,10 @@ type: quickcheck_2019
                 </div>
             </div>
         </div>
-    </div>
+    </div> <!-- end recommendations -->
+
 </div>
 </section>
-
-
 <section id="c_compare" class="tab">
         <div>
             <div>
@@ -155,46 +169,46 @@ type: quickcheck_2019
             </div>
             <div id="perf-comparison">
                 <div>
-                    {{< tab_navigation 
+                    {{< tab_navigation
                         titles="All Industries,Your Industry"
-                        controls="perf-all,perf-industry" 
-                        selected="All Industries" 
+                        controls="perf-all,perf-industry"
+                        selected="All Industries"
                         >}}
                 </div>
                 <div id="perf-all">
                     <div id="perf-all-leadtime-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-all-leadtime-marker"></div>
-                        <div id="perf-all-leadtime"></div>  
+                        <div id="perf-all-leadtime"></div>
                     </div>
                     <div id="perf-all-deployfreq-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-all-deployfreq-marker"></div>
-                        <div id="perf-all-deployfreq"></div>  
+                        <div id="perf-all-deployfreq"></div>
                     </div>
                     <div id="perf-all-ttr-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-all-ttr-marker"></div>
-                        <div id="perf-all-ttr"></div>  
+                        <div id="perf-all-ttr"></div>
                     </div>
                     <div id="perf-all-chgfail-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-all-chgfail-marker"></div>
-                        <div id="perf-all-chgfail"></div>  
+                        <div id="perf-all-chgfail"></div>
                     </div>
                 </div>
                 <div id="perf-industry">
                     <div id="perf-industry-leadtime-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-industry-leadtime-marker"></div>
-                        <div id="perf-industry-leadtime"></div>  
+                        <div id="perf-industry-leadtime"></div>
                     </div>
                     <div id="perf-industry-deployfreq-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-industry-deployfreq-marker"></div>
-                        <div id="perf-industry-deployfreq"></div>  
+                        <div id="perf-industry-deployfreq"></div>
                     </div>
                     <div id="perf-industry-ttr-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-industry-ttr-marker"></div>
-                        <div id="perf-industry-ttr"></div>  
+                        <div id="perf-industry-ttr"></div>
                     </div>
                     <div id="perf-industry-chgfail-container">
                         <div class="icon-container"><img src="/img/quickcheck/icon_you.svg" class="icon" id="perf-industry-chgfail-marker"></div>
-                        <div id="perf-industry-chgfail"></div>  
+                        <div id="perf-industry-chgfail"></div>
                     </div>
                 </div>
             </div>
@@ -231,7 +245,7 @@ type: quickcheck_2019
                   </tr>
                   <tr>
                     <td data-colheader="Lead time for changes">
-                      <h4 class="h-c-headline h-c-headline--subhead h-u-font-weight-medium">Lead time for changes</h4> 
+                      <h4 class="h-c-headline h-c-headline--subhead h-u-font-weight-medium">Lead time for changes</h4>
                       <p>For the primary application or service you work on, what is your lead time for changes (that is, how long does it take to go from code committed to code successfully running in production)?</p>
                     </td>
                     <td data-colheader="Low" id="leadtime-low" class="perf"><span>Low:</span> Between one month and six months</td>
@@ -241,7 +255,7 @@ type: quickcheck_2019
                   </tr>
                   <tr>
                     <td data-colheader="Time to restore service">
-                      <h4 class="h-c-headline h-c-headline--subhead h-u-font-weight-medium">Time to restore service</h4> 
+                      <h4 class="h-c-headline h-c-headline--subhead h-u-font-weight-medium">Time to restore service</h4>
                       <p>For the primary application or service you work on, how long does it generally take to restore service when a service incident or a defect that impacts users occurs (for example, unplanned outage or service impairment)?</p>
                     </td>
                     <td data-colheader="Low" id="ttr-low" class="perf"><span>Low:</span> Between one week and one month</td>
@@ -266,11 +280,14 @@ type: quickcheck_2019
     </div>
 </section>
 
-<div id="modal"  role="dialog" aria-modal="true" aria-labelledby="modal-label" aria-describedby="modal-content">
+<div id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-label" aria-describedby="modal-content">
     <div class="wrapper">
+
         <h1 id="modal-label" >DevOps capabilities assessment</h1>
         <p >Answer the following questions to find out which capability you, as <strong class="color-by-profile">a <span class="profile-title">unknown</span> performer</strong>, should consider focusing on first.</p>
+        <!-- Add in content from .js -->
         <div id="modal-content"></div>
+        <!-- end .js-->
         <p id="modal-error" >You must respond to all questions before results can be calculated.</p>
         <p>
             <img class="modal-close x" aria-controls="modal" src="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/close/default/48px.svg" alt="close">

--- a/hugo/layouts/quickcheck_2019/single.html
+++ b/hugo/layouts/quickcheck_2019/single.html
@@ -1,4 +1,6 @@
 {{ define "main" }}
+<!-- Load Alpine from CDN -->
+<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
     {{ .Content }}
 


### PR DESCRIPTION
Limited changes to 2019 Quick Check functional areas, but could be leveraged in future patterns.

Foundational:  Added AlpineJS include in Main Layout template for 2019.  After full adoption of Alpine (if agreed via ADR), we should move into global level templates.

Functional changes:
**For _Share Results_ and _How was this calculated?_ helper popup**: Added functionality to close window upon: Escape or Enter keys and click outside.

**For "Help Me Prioritize**:    I did not close on Click outside because with the user already clicking various radio buttons, I did not want the user to "loose" their work upon an accidental click off modal.  However, I did add functionality to close window on "Escape" (a more deliberate action, in my opinon.