### PR TITLE
use proper comments in MD files

### DIFF
--- a/hugo/content/research/_index.md
+++ b/hugo/content/research/_index.md
@@ -2,6 +2,7 @@
 title: "Research"
 date: 2023-02-02T18:23:33Z
 draft: false
+# This file contains only the content for the summary at the top of /research/ -- the interactive BFD is provided via the research/section.html template
 ---
 
 # Explore DORA's Research Program
@@ -10,5 +11,3 @@ DORA's research program represents over nine years of research and data from ove
 Use our [quick check tool](/quickcheck/) to discover how you compare to industry peers, identify specific capabilities you can use to improve performance, and make progress toward your software delivery performance goals.
 
 You can also explore our research program using the diagram below, or browse our [capability catalog](/devops-capabilities/). To learn more about research from a particular year, browse the [research archives](/research/archives/).
-
-{{< comment >}} The BFD is included below, as specified in the template for this section. {{ end }}

--- a/hugo/content/research/archives/2017.md
+++ b/hugo/content/research/archives/2017.md
@@ -3,6 +3,7 @@ title: "DORA Reseach: 2017 and earlier"
 date: 2017-10-01
 draft: false
 research_year: 2017 and earlier
+# SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 sections_to_display:
 type: research_archives
 ---
@@ -15,7 +16,3 @@ Prior to 2018, research was conducted in partnership with Puppet, as an extensio
 - [2016 State of DevOps Report](/publications/pdf/state-of-devops-2016.pdf)
 - [2015 State of DevOps Report](/publications/pdf/state-of-devops-2015.pdf)
 - [2014 State of DevOps Report](/publications/pdf/state-of-devops-2014.pdf)
-
-{{< comment >}}
-    SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"
-{{ end }}

--- a/hugo/content/research/archives/2018.md
+++ b/hugo/content/research/archives/2018.md
@@ -3,12 +3,9 @@ title: "DORA Reseach: 2018"
 date: 2018-10-01
 draft: false
 research_year: 2018
+# SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 type: research_archives
 ---
 
 # DORA's Research Program: 2018
 2018 saw the release of the first State of DevOps Report indepently published by DORA. [Read the 2018 report here](/publications/pdf/state-of-devops-2018.pdf)
-
-{{< comment >}}
-    SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"
-{{ end }}

--- a/hugo/content/research/archives/2019.md
+++ b/hugo/content/research/archives/2019.md
@@ -3,6 +3,7 @@ title: "DORA Reseach: 2019"
 date: 2019-10-01
 draft: false
 research_year: 2019
+# SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 sections_to_display:
     - sem
 type: research_archives
@@ -10,7 +11,3 @@ type: research_archives
 
 # DORA's Research Program: 2019
 DORA's research program continued in 2019. [Read the 2019 report here](/publications/pdf/state-of-devops-2019.pdf)
-
-{{< comment >}}
-    SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"
-{{ end }}

--- a/hugo/content/research/archives/2020.md
+++ b/hugo/content/research/archives/2020.md
@@ -3,12 +3,9 @@ title: "DORA Reseach: 2020"
 date: 2020-10-01
 draft: false
 research_year: 2020
+# SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 type: research_archives
 ---
 
 # DORA's Research Program: 2020
 In 2020, DORA didn't write a State of DevOps Report. We did, however, produce a whitepaper which explores the return on investment (ROI) that can be realized through a DevOps transformation project. [Read The ROI of DevOps Whitepaper](https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper)
-
-{{< comment >}}
-    SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"
-{{ end }}

--- a/hugo/content/research/archives/2021.md
+++ b/hugo/content/research/archives/2021.md
@@ -3,6 +3,7 @@ title: "DORA Reseach: 2021"
 date: 2021-10-01
 draft: false
 research_year: 2021
+# SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 sections_to_display:
     - sem
 type: research_archives
@@ -10,7 +11,3 @@ type: research_archives
 
 # DORA's Research Program: 2021
 In 2021, DORA did deep-dive investigations into security, reliability, documentation, and more. You can [read the 2021 report here](/publications/pdf/state-of-devops-2021.pdf). Below are some of the analytical tools used in producing the report.
-
-{{< comment >}}
-    SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"
-{{ end }}

--- a/hugo/content/research/archives/2022.md
+++ b/hugo/content/research/archives/2022.md
@@ -3,6 +3,7 @@ title: "DORA Reseach: 2022"
 date: 2022-10-01
 draft: false
 research_year: 2022
+# SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 sections_to_display:
     - sem
     - questions
@@ -18,7 +19,3 @@ In 2022, DORA continued its investigation into software developmend and operatio
     controls="sem,questions" 
     selected="Structural Equation Models" 
     >}}
-
-{{< comment >}}
-    SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json"
-{{ end }}


### PR DESCRIPTION
Comments in markdown files are kind of a non-thing, so we've been using [a hacky workaround](https://github.com/dora-team/dora.dev/blob/ccc4ea6b744b706dfbd3e28a4a396d4398b43056/hugo/content/research/archives/2018.md?plain=1#L12-L14). 

But TIL that in the _front matter_ of markdown files, we can use a simple `#` prefix to make comments. That feels like a reasonable compromise and makes the files nicer to look at; this PR adopts that format.