### PR TITLE
Make Publications responsive-er

### DIFF
--- a/hugo/assets/scss/publications.scss
+++ b/hugo/assets/scss/publications.scss
@@ -37,7 +37,6 @@
 
             img {
                 max-width:32em;
-                max-height:24em;
                 width: 100%;
             }
 

--- a/hugo/assets/scss/publications.scss
+++ b/hugo/assets/scss/publications.scss
@@ -38,6 +38,7 @@
             img {
                 max-width:32em;
                 max-height:24em;
+                width: 100%;
             }
 
             a {
@@ -55,6 +56,12 @@
                 text-decoration: none;
                 font-size: 100%;
             }
+        }
+    }
+
+    @include media-large {
+        ul {
+            grid-template-columns: 1fr 1fr;
         }
     }
 


### PR DESCRIPTION
This helps to resolve issue #142 

1. The grid reduces to two columns at the "large" breakpoint
2. The images are set to 100%, so they take up the available width at intermediate sizes

Max screens
![Three columns on extra-large sizes](https://user-images.githubusercontent.com/1036595/235939847-6bf9d410-6758-4483-9e1e-7e0300a3e38d.png)

Medium and large screens
![Two columns on large and medium sizes](https://user-images.githubusercontent.com/1036595/235939976-0ec3281e-25ea-4aac-86ce-8643bdf6368c.png)

Small screens
![One column on small screens](https://user-images.githubusercontent.com/1036595/235940087-6f58f030-037d-454f-a415-83a924d74905.png)
