### PR TITLE
add redirect for `/survey.`

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -43,6 +43,11 @@
           "source": "/dora-joins-google-cloud.html",
           "destination": "/news/dora-joins-google-cloud/",
           "type": 301
+        },
+        {
+          "source": "/survey.",
+          "destination": "/survey/",
+          "type": 301
         }
       ]
     },


### PR DESCRIPTION
I've noticed some requests to `/survey.`, which returns a 404. Let's get these folks where they're trying to go (`/survey/`).