### PR TITLE
Remove boilerplate (Fixes #176)

### DIFF
--- a/hugo/content/devops-capabilities/cultural/generative-organizational-culture/index.md
+++ b/hugo/content/devops-capabilities/cultural/generative-organizational-culture/index.md
@@ -8,17 +8,7 @@ headline: "Discover how growing a generative, high-trust culture drives better o
 summary: "Measure of organizational culture is based on a typology developed by Ron Westrum, a sociologist who studied safety-critical complex systems in the domains of aviation and healthcare. Our own research has found that this measure of culture is predictive of IT Performance, organizational performance, and decreasing burnout. Hallmarks of this include good information flow, high cooperation and trust, bridging between teams, and embracing novel solutions."
 ---
 
-<!-- TODO: Add NOTE banner to the below section -->
-
-Note: *Westrum organizational culture* is one of a set of capabilities that
-drive higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](https://www.devops-research.com/research.html),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
-According to research by DevOps Research and Assessment (DORA), organizational
+According to research by [DevOps Research and Assessment (DORA)](https://dora.dev), organizational
 culture that is high-trust and emphasizes information flow is predictive of
 software delivery performance and organizational performance in technology. The
 idea that a good culture that optimizes information flow is predictive of good

--- a/hugo/content/devops-capabilities/cultural/job-satisfaction/index.md
+++ b/hugo/content/devops-capabilities/cultural/job-satisfaction/index.md
@@ -11,20 +11,8 @@ Where there's job satisfaction, employees bring the best of themselves to work:
 their engagement, their creativity, and their strongest thinking."
 ---
 
-<!-- # DevOps culture: Job satisfaction -->
-
-<!-- TODO: Add NOTE banner to the below section -->
-
-Note: *Job satisfaction* is one of a set of capabilities that drive higher
-software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Early analysis performed by
-[DevOps Research and Assessment (DORA)](https://cloud.google.com/devops)
+[DevOps Research and Assessment (DORA)](https://dora.dev)
 found that job satisfaction is a predictor of organizational
 performance. Having engaged employees doing meaningful work drives business
 value.

--- a/hugo/content/devops-capabilities/cultural/learning-culture/index.md
+++ b/hugo/content/devops-capabilities/cultural/learning-culture/index.md
@@ -8,17 +8,7 @@ headline: "Grow a learning culture and understand its impact on your organizatio
 summary: "A culture’s attitudes towards learning and if it is valued. For example, is learning considered essential for continued progress? Is learning thought of as a cost, or an investment? This is a measure of an organization’s learning culture."
 ---
 
-<!-- TODO: Add NOTE banner to the below section -->
-Note: *Learning culture* is one of a set of capabilities that drive higher
-software delivery and organizational performance.  These capabilities were
-discovered by the
-[DORA State of DevOps research program](https://www.devops-research.com/research.html),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
-Research from the [DevOps Research and Assessment (DORA)](https://services.google.com/fh/files/misc/state-of-devops-2014.pdf)
-(PDF) team shows that an
+Research from the [DevOps Research and Assessment (DORA)](https://dora.dev) team shows that an
 organizational culture that values learning contributes to
 software delivery performance with the following:
 

--- a/hugo/content/devops-capabilities/cultural/transformational-leadership/index.md
+++ b/hugo/content/devops-capabilities/cultural/transformational-leadership/index.md
@@ -8,17 +8,7 @@ headline: "Learn how effective leaders influence software delivery performance b
 summary: "Effective leadership has a measurable, significant impact on software delivery outcomes. However, rather than driving these outcomes directly, effective transformational leaders influence software delivery performance by enabling the adoption of technical and product management capabilities and practices by practitioners, which in turn drives the outcomes leaders care about."
 ---
 
-<!-- TODO: Add NOTE banner to the below section -->
-
-Note: *Transformational leadership* is one of a set of capabilities that drive
-higher software delivery and organizational performance.
-These capabilities were discovered by the
-[DORA State of DevOps research program](https://www.devops-research.com/research.html),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
-[DevOps Research and Assessment (DORA)](https://cloud.google.com/devops) research shows that effective leadership has a measurable, significant
+[DevOps Research and Assessment (DORA)](https://dora.dev) research shows that effective leadership has a measurable, significant
 impact on software delivery outcomes. However, rather than driving these
 outcomes directly, effective transformational leaders influence software
 delivery performance by enabling the adoption of technical and product

--- a/hugo/content/devops-capabilities/process/customer-feedback/index.md
+++ b/hugo/content/devops-capabilities/process/customer-feedback/index.md
@@ -8,14 +8,6 @@ headline: "Drive better organizational outcomes by gathering customer feedback a
 summary: "A summary (150-250 words) that describes this capability."
 ---
 
-Note: *Customer feedback* is one of a set of capabilities that drive higher
-software delivery and organizational performance.  These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 In software projects, developers often work on products for months or years,
 sometimes for multiple releases without validating whether the features they're
 building are actually helping users solve their problems, or whether the

--- a/hugo/content/devops-capabilities/process/monitoring-systems/index.md
+++ b/hugo/content/devops-capabilities/process/monitoring-systems/index.md
@@ -8,14 +8,6 @@ headline: "Improve monitoring across infrastructure platforms, middleware, and t
 summary: "Improve monitoring across infrastructure platforms, middleware, and the application tier, so you can provide fast feedback to developers."
 ---
 
-Note: *Monitoring systems to inform business decisions* is one of a set of
-capabilities that drive higher software delivery and organizational
-performance.  These capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Monitoring is the process of collecting, analyzing, and using information to
 track applications and infrastructure in order to guide business decisions.
 Monitoring is a key capability because it gives you insight into your systems

--- a/hugo/content/devops-capabilities/process/proactive-failure-notification/index.md
+++ b/hugo/content/devops-capabilities/process/proactive-failure-notification/index.md
@@ -8,14 +8,6 @@ headline: "Set proactive failure notifications to identify critical issues and a
 summary: "Set proactive failure notifications to identify critical issues and act on problems before they arise."
 ---
 
-Note: *Proactive failure notification* is one of a set of capabilities
-that drive higher software delivery and organizational performance.
-These capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Proactive failure notification is the practice of generating notifications when
 monitored values approach known failure thresholds, and not waiting for the
 system to alert you it has already failed — or worse, to find out from customers

--- a/hugo/content/devops-capabilities/process/streamlining-change-approval/index.md
+++ b/hugo/content/devops-capabilities/process/streamlining-change-approval/index.md
@@ -8,14 +8,6 @@ headline: "Replace heavyweight change-approval processes with peer review, to ge
 summary: "Replace heavyweight change-approval processes with peer review, to get the benefits of a more reliable, compliant release process without sacrificing speed."
 ---
 
-Note: *Streamlining change approval* is one of a set of capabilities
-that drive higher software delivery and organizational performance.
-These capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Most IT organizations have change management processes to manage the life cycle
 of changes to IT services, both internal and customer-facing. These processes
 are often the primary controls to reduce the operational and security risks of

--- a/hugo/content/devops-capabilities/process/team-experimentation/index.md
+++ b/hugo/content/devops-capabilities/process/team-experimentation/index.md
@@ -8,14 +8,6 @@ headline: "Innovate faster by building empowered teams that can try out new idea
 summary: "Innovate faster by building empowered teams that can try out new ideas without approval from people outside the team."
 ---
 
-Note: *Team experimentation* is one of a set of capabilities that drive
-higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Even in many so-called agile teams, developers can only work on requirements or
 stories that are given to them. And despite the developers’ specialist
 knowledge, or what they discover in the development process, they can’t change

--- a/hugo/content/devops-capabilities/process/visual-management/index.md
+++ b/hugo/content/devops-capabilities/process/visual-management/index.md
@@ -8,15 +8,6 @@ headline: "Learn about the principles of visual management to promote informatio
 summary: "Learn about the principles of visual management to promote information sharing, get a common understanding of where the team is, and how to improve."
 ---
 
-
-Note: *Visual management capabilities* is one of a set of capabilities
-that drive higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 It's a common practice for teams that are adopting
 [lean development practices](https://wikipedia.org/wiki/Lean_software_development)
 to display key information about their processes in team areas where everybody

--- a/hugo/content/devops-capabilities/process/wip-limits/index.md
+++ b/hugo/content/devops-capabilities/process/wip-limits/index.md
@@ -8,14 +8,6 @@ headline:  "Prioritize work, limit the amount of things that people are working 
 summary: "Prioritize work, limit the amount of things that people are working on, and focus on getting a small number of high-priority tasks done."
 ---
 
-Note: *Work in process limits* is one of a set of capabilities that
-drive higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 When faced with too much work and too few people to do it, rookie managers
 assign people to work on multiple tasks in the hope of increasing throughput.
 Unfortunately, the result is that tasks take longer to get done, and the team

--- a/hugo/content/devops-capabilities/process/work-visibility-in-value-stream/index.md
+++ b/hugo/content/devops-capabilities/process/work-visibility-in-value-stream/index.md
@@ -8,14 +8,6 @@ headline: "Understand and visualize the flow of work from idea to customer outco
 summary: "Understand and visualize the flow of work from idea to customer outcome in order to drive higher performance."
 ---
 
-Note: *Visibility of work in the value stream* is one of a set of
-capabilities that drive higher software delivery and organizational
-performance.  These capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 *Visibility of work* represents the extent to which teams have a good
 understanding of the flow of work from the business all the way through to
 customers, and whether they have visibility into this flow, including the status

--- a/hugo/content/devops-capabilities/process/working-in-small-batches/index.md
+++ b/hugo/content/devops-capabilities/process/working-in-small-batches/index.md
@@ -8,14 +8,6 @@ headline: "Create shorter lead times and faster feedback loops by working in sma
 summary: "Create shorter lead times and faster feedback loops by working in small batches. Learn common obstacles to this critical capability and how to overcome them."
 ---
 
-Note: *Working in small batches* is one of a set of capabilities
-that drive higher software delivery and organizational performance.
-These capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Working in small batches is an essential principle in any discipline where
 feedback loops are important, or you want to learn quickly from your
 decisions. Working in small batches allows you to rapidly test hypotheses about

--- a/hugo/content/devops-capabilities/technical/cloud-infrastructure/index.md
+++ b/hugo/content/devops-capabilities/technical/cloud-infrastructure/index.md
@@ -8,16 +8,6 @@ headline: "Find out how to manage cloud infrastructure effectively so you can ac
 summary: "Find out how to manage cloud infrastructure effectively so you can achieve higher levels of agility, availability, and cost visibility."
 ---
 
-
-Note: *Cloud infrastructure* is one of a set of capabilities that
-drive higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
-
 Many organizations are adopting cloud computing. But there's more to cloud than
 buying your infrastructure from a cloud provider. The US National Institute of
 Standards and Technologies (NIST)

--- a/hugo/content/devops-capabilities/technical/code-maintainability/index.md
+++ b/hugo/content/devops-capabilities/technical/code-maintainability/index.md
@@ -8,14 +8,6 @@ headline: "Make it easy for developers to find, reuse, and change code, and keep
 summary: "Make it easy for developers to find, reuse, and change code, and keep dependencies up-to-date."
 ---
 
-Note: *Code maintainability* is one of a set of capabilities that drive higher
-software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 It takes
 [a lot of code](https://www.businessinsider.com/how-many-lines-of-code-it-takes-to-run-different-software-2017-2)
 to run the systems we build: The Android operating system runs on 12 to 15

--- a/hugo/content/devops-capabilities/technical/continuous-delivery/index.md
+++ b/hugo/content/devops-capabilities/technical/continuous-delivery/index.md
@@ -8,14 +8,6 @@ headline: "Make deploying software a reliable, low-risk process that can be perf
 summary: "Make deploying software a reliable, low-risk process that can be performed on demand at any time."
 ---
 
-Note: *Continuous delivery* is one of a set of capabilities that drive
-higher software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Continuous delivery is the ability to release changes of all kinds on demand
 quickly, safely, and sustainably. Teams that practice continuous delivery well
 are able to release software and make changes to production in a low-risk way at

--- a/hugo/content/devops-capabilities/technical/continuous-integration/index.md
+++ b/hugo/content/devops-capabilities/technical/continuous-integration/index.md
@@ -8,14 +8,6 @@ headline: "Learn about common mistakes, ways to measure, and how to improve on y
 summary: "Learn about common mistakes, ways to measure, and how to improve on your continuous integration efforts."
 ---
 
-Note: *Continuous integration* is one of a set of capabilities that drive
-higher software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Software systems are complex, and an apparently simple, self-contained change
 to a single file can have unintended side effects on the overall system. When a
 large number of developers work on related systems, coordinating code updates is

--- a/hugo/content/devops-capabilities/technical/database-change-management/index.md
+++ b/hugo/content/devops-capabilities/technical/database-change-management/index.md
@@ -8,16 +8,8 @@ headline: "Make sure database changes don't cause problems or slow you down."
 summary: "Make sure database changes don't cause problems or slow you down."
 ---
 
-Note: *Database change management* is one of a set of capabilities that drive
-higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Database changes are often a major source of risk and delay when performing
-deployments. [DevOps Research and Assessment (DORA)](https://cloud.google.com/devops) investigated which database-related practices help during the process of implementing continuous delivery, improving both software delivery performance and availability.
+deployments. [DevOps Research and Assessment (DORA)](https://dora.dev) investigated which database-related practices help during the process of implementing continuous delivery, improving both software delivery performance and availability.
 
 DORA's research found that integrating database work into the software delivery
 process positively contributes to

--- a/hugo/content/devops-capabilities/technical/deployment-automation/index.md
+++ b/hugo/content/devops-capabilities/technical/deployment-automation/index.md
@@ -8,14 +8,6 @@ headline: "Best practices and approaches for deployment automation and reducing 
 summary: "Best practices and approaches for deployment automation and reducing manual intervention in the release process."
 ---
 
-Note: *Deployment automation* is one of a set of capabilities that drive
-higher software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Deployment automation is what enables you to deploy your software to testing
 and production environments with the push of a button. Automation is essential
 to reduce the risk of production deployments. It's also essential for providing

--- a/hugo/content/devops-capabilities/technical/loosely-coupled-architecture/index.md
+++ b/hugo/content/devops-capabilities/technical/loosely-coupled-architecture/index.md
@@ -8,15 +8,7 @@ headline: "Learn about moving from a tightly coupled architecture to service-ori
 summary: "Learn about moving from a tightly coupled architecture to service-oriented and microservice architectures without re-architecting everything at once"
 ---
 
-Note: *Architecture* is one of a set of capabilities that drive higher software
-delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
-Research from the DevOps Research and Assessment (DORA) team shows that
+Research from the [DevOps Research and Assessment (DORA)](https://dora.dev) team shows that
 architecture is an important predictor for achieving continuous delivery.
 Whether you're using Kubernetes or mainframes, your architecture enables teams
 to adopt practices that foster higher levels of software delivery performance.

--- a/hugo/content/devops-capabilities/technical/monitoring-and-observability/index.md
+++ b/hugo/content/devops-capabilities/technical/monitoring-and-observability/index.md
@@ -8,16 +8,8 @@ headline: "Learn how to build tooling to help you understand and debug your prod
 summary: "Learn how to build tooling to help you understand and debug your production systems."
 ---
 
-Note: *Monitoring and observability* is one of a set of capabilities that
-drive higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Good monitoring is a staple of high-performing teams.
-[DevOps Research and Assessment (DORA)](https://cloud.google.com/devops)
+[DevOps Research and Assessment (DORA)](https://dora.dev)
 [research](/publications/pdf/state-of-devops-2018.pdf)
 shows that a comprehensive monitoring and observability solution, along with a
 number of other technical practices, positively contributes to

--- a/hugo/content/devops-capabilities/technical/shifting-left-on-security/index.md
+++ b/hugo/content/devops-capabilities/technical/shifting-left-on-security/index.md
@@ -8,14 +8,6 @@ headline: "Build security into the software development lifecycle without compro
 summary: "Build security into the software development lifecycle without compromising delivery speed."
 ---
 
-Note: *Shifting left on security* is one of a set of capabilities that drive
-higher software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Security is everyone's responsibility. The
 [2016 State of DevOps Report](/publications/pdf/state-of-devops-2016.pdf)
 (PDF) research shows that high-performing teams spend 50 percent less time

--- a/hugo/content/devops-capabilities/technical/teams-empowered-to-choose-tools/index.md
+++ b/hugo/content/devops-capabilities/technical/teams-empowered-to-choose-tools/index.md
@@ -8,14 +8,6 @@ headline: "Empower teams to make informed decisions on tools and technologies. L
 summary: "Empower teams to make informed decisions on tools and technologies. Learn how these decisions drive more effective software delivery."
 ---
 
-Note: *Empowering teams to choose tools* is one of a set of capabilities
-that drive higher software delivery and organizational performance. These
-capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 If you want to achieve higher software delivery performance and increase the
 [job satisfaction](/devops-capabilities/cultural/job-satisfaction)
 of your technical staff, you should empower them to make informed choices about

--- a/hugo/content/devops-capabilities/technical/test-automation/index.md
+++ b/hugo/content/devops-capabilities/technical/test-automation/index.md
@@ -8,16 +8,6 @@ headline: "Improve software quality by building reliable automated test suites a
 summary: "Improve software quality by building reliable automated test suites and performing all kinds of testing throughout the software delivery lifecycle."
 ---
 
-
-
-Note: *Test automation* is one of a set of capabilities that drive higher
-software delivery and organizational performance.  These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 The key to building quality into software is getting fast feedback on the impact
 of changes throughout the software delivery lifecycle. Traditionally, teams
 relied on manual testing and code inspection to verify systems' correctness.

--- a/hugo/content/devops-capabilities/technical/test-data-management/index.md
+++ b/hugo/content/devops-capabilities/technical/test-data-management/index.md
@@ -8,15 +8,6 @@ headline: "Understand the right strategies for managing test data effectively al
 summary: "Understand the right strategies for managing test data effectively along with approaches to provide fast, secure data access for testing."
 ---
 
-
-Note: *Test data management* is one of a set of capabilities that drive higher
-software delivery and organizational performance. These capabilities were
-discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 [Automated testing](/devops-capabilities/technical/test-automation)
 is a key component of modern software delivery practices. The ability to execute
 a comprehensive set of unit, integration, and system tests is essential to

--- a/hugo/content/devops-capabilities/technical/trunk-based-development/index.md
+++ b/hugo/content/devops-capabilities/technical/trunk-based-development/index.md
@@ -8,14 +8,6 @@ headline: "Prevent merge-conflict hassles with trunk-based development practices
 summary: "Prevent merge-conflict hassles with trunk-based development practices."
 ---
 
-Note: *Trunk-based development* is one of a set of capabilities that drive
-higher software delivery and organizational performance.
-These capabilities were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 There are two main patterns for developer teams to work together using version
 control. One is to use *feature branches*, where either a developer or a group
 of developers create a branch usually from trunk (also known as *main* or

--- a/hugo/content/devops-capabilities/technical/version-control/index.md
+++ b/hugo/content/devops-capabilities/technical/version-control/index.md
@@ -8,14 +8,6 @@ headline: "A guide to implementing the right version control practices for repro
 summary: "A guide to implementing the right version control practices for reproducibility and traceability."
 ---
 
-Note: *Version control* is one of a set of capabilities that drive higher
-software delivery and organizational performance.  These capabilities
-were discovered by the
-[DORA State of DevOps research program](/),
-an independent, academically rigorous investigation into the practices and
-capabilities that drive high performance. To learn more, read our
-[DevOps resources](https://cloud.google.com/devops).
-
 Version control systems like Git, Subversion, and Mercurial provide a logical
 means to organize files and coordinate their creation, controlled access,
 updating, and deletion across teams and organizations. Version control is


### PR DESCRIPTION
This PR removes the boilerplate copy at the top of every capability article. (That copy is no longer necessary, as discussed in #167.)

Fixes #176