### PR TITLE
Remove survey CTAs  (Fixes #270)

### DIFF
--- a/hugo/content/survey/index.md
+++ b/hugo/content/survey/index.md
@@ -9,8 +9,13 @@ Over the past eight years, more than 33,000 professionals around the world have 
 
 In addition to contributing to our collective understanding of software delivery, the survey offers practitioners a time to reflect on challenges and opportunities within their own teams.
 
+### The 2023 Accelerate State of DevOps survey is now closed.
+Thank you to everyone who participated! We plan to publish the 2023 Accelerate State of DevOps Report this fall. To be notified when it's released, [join the DORA community](https://dora.community).
+
+<!--
 ## Participate in the Accelerate State of DevOps Survey
 
 **The survey is now open!** Take a moment to reflect on your work, and share your experience to enrich this year's research. Most participants are able to complete the survey in about 15 minutes.
 
 {{< button href="https://google.qualtrics.com/jfe/form/SV_3jHsoEmQR877LW6?source=doradotdev-survey" target="_blank" >}}Take the 2023 Accelerate State of DevOps Survey now!{{< /button >}}
+-->

--- a/hugo/layouts/partials/site_banner.html
+++ b/hugo/layouts/partials/site_banner.html
@@ -1,3 +1,5 @@
+{{/*
 <div class="site-banner">
     The 2023 Accelerate State of DevOps Survey is now open! <a href="https://google.qualtrics.com/jfe/form/SV_3jHsoEmQR877LW6?source=doradotdevbanner" target="_blank">Take the survey now</a>
 </div>
+*/}}


### PR DESCRIPTION
_DO NOT MERGE until the survey has closed!_

This PR removes the survey banner from all pages, and updates the content of `/survey`.

(Note that when we publish SODR 2023, we should update the stats on this page, but for now we can stick with the c. 2022 numbers)

Fixes #270