### PR TITLE
Initial i18n skaffolding

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -2,7 +2,7 @@
 
 ## Environments
 There are two persistent hosting environments (powered by Firebase): [Staging](https://staging.dora.com/) and [Prod](https://dora.dev/).
-_Also, ephemeral environments are created during CI (see below)._
+_Also, ephemeral environments—in "draft" and "prod" modes—are created during CI (see below)._
 
 ## Publishing
 This site is hosted on Firebase, so deployment requires a Firebase builder for Cloud Build. We use [the public community builder](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/firebase). It must be built and pushed into your project's Container Registry repo.
@@ -14,8 +14,10 @@ Also, a secret named `github_token` must exist in Secret Manager, which contains
 #### Content preview
 If a PR includes changes to files in the `/hugo` directory, the pipeline `/ci/preview-content.cloudbuild.yaml` is executed in project `doradotdev`. This pipeline:
 
-1. Renders the site in _draft_ mode (including content where "Draft" is true), and publishes it to a Firebase preview channel
-1. Renders the site in _production_ mode (excluding content where "Draft" is true) and publishes it to a different Firebase preview channel
+1. **Draft preview:** Renders the site in _draft_ mode (including content where "Draft" is true), with the Hugo environment set to "draft", and publishes it to a Firebase preview channel
+  1. The use of the environment setting allows for conditionals inside of templates—for example, a new UI control may be relevant only to draft content, so it will only be displayed on the draft preview
+    1. Unfortunately, as far as I (Dave) can tell, there's no way to simply infer that the `-D` flag was set at render time; Hugo does provide for conditionals like `{{ if eq .Draft true }}`, but that reflects the setting in the front matter—ie. it's true if the _content_ is "Draft", it's not based on the render mode.
+1. **Prod preview:** Renders the site in _production_ mode (excluding content where "Draft" is true) and publishes it to a different Firebase preview channel
 1. Posts both preview channel links to the PR as comments
 
 #### Infra preview

--- a/ci/preview-content.cloudbuild.yaml
+++ b/ci/preview-content.cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: gcr.io/$PROJECT_ID/hugo
     script: |
       # Build draft site
-      hugo -D -v -s ./hugo -d /workspace/hugo/public --debug
+      hugo -v -s ./hugo -d /workspace/hugo/public --debug -D --environment=draft
 
   - name: gcr.io/$PROJECT_ID/firebase
     env:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 The following development with Hugo will be sufficient for most of the DORA.dev website development efforts.
 To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (recommended version: [v0.114.1](https://github.com/gohugoio/hugo/releases/tag/v0.114.1)).
 
-- The recommended command to start the local hugo server is `hugo serve -D -s hugo --disableFastRender --debug --watch`.
-  - This will render and live-reload all pages, including drafts. _To suppress rendering of drafts, omit the `-D` flag._
+- The recommended command to start the local hugo server is `hugo serve -s hugo --disableFastRender --debug --watch -D --environment=draft`.
+  - This will render and live-reload all pages, including drafts. _To suppress rendering of drafts and draft-related page elements, omit the following flags: `-D --environment=draft`._
 - When the hugo server is running, the site can be previewed at `localhost:1313`.
 
 ## CI/CD

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -12,3 +12,13 @@ unsafe= true
   changefreq = 'monthly'
   filename = 'sitemap.xml'
   priority = 0.5
+
+DefaultContentLanguage = 'en'
+
+[languages]
+    [languages.en]
+        languageName = "English"
+        weight = 1
+    [languages.fr]
+        languageName = "Français"
+        weight = 2

--- a/hugo/content/devops-capabilities/_index.fr.md
+++ b/hugo/content/devops-capabilities/_index.fr.md
@@ -1,0 +1,7 @@
+---
+title: <<DEVOPS CAPABILITIES (but in French)>>
+bannerTitle: <<CAPABILITY CATALOG (but in French)>>
+bannerSubtitle: TRANSLATE ME to French
+draft: true
+---
+

--- a/hugo/content/devops-capabilities/technical/cloud-infrastructure/index.fr.md
+++ b/hugo/content/devops-capabilities/technical/cloud-infrastructure/index.fr.md
@@ -1,0 +1,13 @@
+---
+title: "Cloud infrastructure"
+titleForHTMLHead: "DevOps Capabilities: Cloud Infrastructure" # TODO: can we DRY this out?
+date: 2023-03-27T09:48:50+01:00
+category: technical
+draft: true
+headline: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+summary: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+---
+
+**I AM FRENCH** (but not really... and I'm not really Latin, either)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/hugo/layouts/devops-capabilities/section.html
+++ b/hugo/layouts/devops-capabilities/section.html
@@ -2,6 +2,9 @@
     <!-- TODO: #121 make a partial to process scss files and render <link> tags -->
     {{ $stylesheet := printf "scss/devops-capabilities.scss" | resources.Get | toCSS | fingerprint }}
     <link rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}">
+    <div style="text-align: right;">
+        {{- partial "language_selector" . -}}
+    </div>
     <h2>Technical capabilities</h2>
     <section class="capabilitiesGrid">
         {{ $capabilities := where site.RegularPages "Params.category" "technical" }}

--- a/hugo/layouts/devops-capabilities/single.html
+++ b/hugo/layouts/devops-capabilities/single.html
@@ -3,7 +3,7 @@
 {{ $stylesheet := printf "scss/devops-capabilities.scss" | resources.Get | toCSS | fingerprint }}
 <link rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}">
 
-<h4><a href="/devops-capabilities">DevOps capabilities</a></h4>
+<h4><a href={{ relLangURL "/devops-capabilities" }}>DevOps capabilities</a></h4>
 <h1>{{ .Title }}</h1>
 <section class="hasSidebar">
     <article>
@@ -11,6 +11,7 @@
     </article>
     <sidebar>
         <section>
+            {{- partial "language_selector" . -}}
             <h4>DevOps Capabilities</h4>
             <h5>Technical</h5>
             <ul>

--- a/hugo/layouts/partials/language_selector.html
+++ b/hugo/layouts/partials/language_selector.html
@@ -1,0 +1,10 @@
+<!--- during development, this widget only appears when draft rendering is enabled -->
+{{ if eq hugo.Environment "draft" }}
+    {{ if .Translations }}
+        <select x-ref="translations" @change="window.location = $refs.translations.value">
+            {{ range $.AllTranslations }}
+                <option value="{{.RelPermalink}}" {{if eq .Lang $.Lang}} selected {{end}}>{{ .Language.LanguageName }}</option>
+            {{ end }}
+        </select>
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
This PR adds some config for adding French pages (I'm using French in development, but our i18n launch will include ~8 languages), and a dropdown menu to navigate between them.

None of this will be visible on the prod site; it only displays in "Draft" environments.

For the time being, anything other than the capability catalog (and Core) is out of scope for i18n, but we hope to translate the entire site, as quickly as we're able.