### PR TITLE
additional translated content

### DIFF
--- a/misc/additional-translated-content/capabilities.de.html
+++ b/misc/additional-translated-content/capabilities.de.html
@@ -1,0 +1,247 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>DevOps-Ressourcen</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="refresh_date" value="2019-08-08"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+Das <a href="https://www.devops-research.com/research.html">DevOps Research and Assessment (DORA)</a>-Team hat eine Reihe von Funktionen identifiziert und validiert, die die Softwarebereitstellung und die Leistung verbessern. In diesen Artikeln wird beschrieben, wie Sie diese Funktionen implementieren, verbessern und analysieren.
+
+</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="Technische Fähigkeiten">Technische Fähigkeiten</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="Versionsverwaltung">Versionsverwaltung</h3>
+   <p>Ein Leitfaden zur Implementierung der richtigen Praktiken für die Versionsverwaltung, um für Reproduzierbarkeit und Rückverfolgbarkeit zu sorgen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="Entwicklung nach Baumschema">Entwicklung nach Baumschema</h3>
+   <p>
+    Vermeiden Sie mit Entwicklungspraktiken nach einem Baumschema Probleme aufgrund von Konflikten beim Zusammenführen.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="Continuous Integration">Continuous Integration</h3>
+   <p>Erfahren Sie mehr über häufige Fehler, Messmethoden und Möglichkeiten zur Verbesserung Ihrer Continuous Integration-Maßnahmen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="Bereitstellungsautomatisierung">Bereitstellungsautomatisierung</h3>
+   <p>Best Practices und Konzepte zur Automatisierung der Bereitstellung und Reduzierung manueller Eingriffe in den Freigabeprozess.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="Kontinuierliche Tests">Kontinuierliche Tests</h3>
+   <p>Sie können die Softwarequalität verbessern. Erstellen Sie dazu zuverlässige automatisierte Testsuites und führen Sie im gesamten Lebenszyklus der Softwarebereitstellung alle Arten von Tests.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="Continuous Delivery">Continuous Delivery</h3>
+   <p>Die Bereitstellung von Software muss zuverlässig und mit geringem Risiko verbunden sein und jederzeit bei Bedarf ausgeführt werden können.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="Architektur">Architektur</h3>
+   <p>So wechseln Sie von einer eng gekoppelten Architektur zu einer serviceorientierten Architektur mit Mikrodiensten, ohne gleich alles neu erstellen zu müssen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="Teams die Tools auswählen lassen">Teams die Tools auswählen lassen</h3>
+   <p>
+    Übertragen Sie die Aufgabe, fundierte Entscheidungen zu Tools und Technologien zu treffen, auf Ihre Teams. So führen diese Entscheidungen zu einer effektiveren Softwarebereitstellung.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="Testdaten verwalten">Testdaten verwalten</h3>
+   <p>Lernen Sie die richtigen Strategien für die effektive Verwaltung von Testdaten sowie Konzepte kennen, die beim Testen einen schnellen und sicheren Datenzugriff ermöglichen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="Ein Linksruck bei der Sicherheit">Ein Linksruck bei der Sicherheit</h3>
+   <p>Binden Sie das Thema Sicherheit frühzeitig in den Softwareentwicklungszyklus ein, ohne die Bereitstellungsgeschwindigkeit zu beeinträchtigen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="Änderungsmanagement für Datenbanken">Änderungsmanagement für Datenbanken</h3>
+   <p>Achten Sie darauf, dass Datenbankänderungen keine Probleme verursachen oder Sie ausbremsen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="Cloud-Infrastruktur">Cloud-Infrastruktur</h3>
+   <p>Hier erfahren Sie, wie Sie eine Cloud-Infrastruktur effizient verwalten, um eine höhere Agilität, Verfügbarkeit und Kostensichtbarkeit zu erreichen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="Verwaltbarkeit von Codes">Verwaltbarkeit von Codes</h3>
+   <p>Machen Sie es Entwicklern einfach, Code zu finden, wiederzuverwenden und zu ändern sowie Abhängigkeiten auf dem neuesten Stand zu halten.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="Prozessfähigkeiten">Prozessfähigkeiten</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="Teamexperimente">Teamexperimente</h3>
+   <p>Entwickeln Sie schneller Innovationen durch den Aufbau von Teams, die ohne Genehmigung einer Person außerhalb des Teams neue Ideen ausprobieren können.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="Ablauf von Änderungsgenehmigungen optimieren">Ablauf von Änderungsgenehmigungen optimieren</h3>
+   <p>Ersetzen Sie schwerfällige Abläufe zur Änderungsgenehmigung durch eine Begutachtung durch Kollegen. So können Sie Freigabeprozesse zuverlässig und regelkonform gestalten, ohne dass die Geschwindigkeit darunter leidet.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="Kundenfeedback">Kunden-Feedback</h3>
+   <p>Steigern Sie den Erfolg des Unternehmens. Erfassen Sie dazu das Kundenfeedback und lassen Sie es beim Entwerfen der Produkte und Features einfließen.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="Sichtbarkeit der Arbeit im Wertstrom">Sichtbarkeit der Arbeit im Wertstrom</h3>
+   <p>Erweitern Sie Ihr Verständnis für den Arbeitsfluss und visualisieren Sie diesen von der Idee bis zum Ergebnis für den Kunden. So erzielen Sie eine höhere Leistung.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="Arbeitsaufteilung">Arbeitsaufteilung</h3>
+   <p>
+    Sorgen Sie für kürzere Vorlaufzeiten und einen schnelleren Feedbackprozess, indem Sie die Arbeit in kleine Posten aufteilen. Lernen Sie die häufigsten Hindernisse für diese wichtige Fähigkeit kennen und erfahren Sie, wie Sie sie beseitigen können.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="Analysefähigkeiten">Analysefähigkeiten</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="Monitoringsysteme für fundierte Geschäftsentscheidungen">Monitoringsysteme für fundierte Geschäftsentscheidungen</h3>
+   <p>Verbessern Sie das Monitoring von Infrastrukturplattformen, Middleware und Anwendungsebenen, damit Sie Entwicklern schnell Feedback geben können.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="Monitoring und Beobachtbarkeit">Monitoring und Beobachtbarkeit</h3>
+   <p>Erfahren Sie, wie Sie Tools erstellen, die Ihnen dabei helfen, Ihre Produktionssysteme besser zu verstehen und Fehler zu beheben.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="Proaktive Fehlerbenachrichtigung">Proaktive Fehlerbenachrichtigung</h3>
+   <p>Richten Sie die proaktiven Fehlerbenachrichtigungen ein, um zentrale Probleme zu identifizieren und darauf reagieren zu können, bevor sie auftreten.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="Umfang laufender Arbeiten begrenzen">Umfang laufender Arbeiten begrenzen</h3>
+   <p>Legen Sie Prioritäten für die Arbeit fest. Dabei sollten Sie die Anzahl der Aufgaben, an denen gearbeitet wird, begrenzen und sich darauf konzentrieren, dass eine geringe Anzahl von Aufgaben mit hoher Priorität erledigt wird.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="Fähigkeiten des visuellen Managements">Fähigkeiten des visuellen Managements</h3>
+   <p>Erfahren Sie mehr über die Grundsätze des visuellen Managements zur Förderung des Informationsaustauschs. Sorgen Sie außerdem für ein gemeinsames Verständnis dafür, an welchem Punkt sich das Team befindet und wie es sich verbessern kann.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="Kulturelle Fähigkeiten">Kulturelle Fähigkeiten</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Unternehmenskultur nach Westrum">Unternehmenskultur nach Westrum</h3>
+   <p>
+    So führt der Aufbau einer generativen Vertrauenskultur zu einer besseren Unternehmensleistung und einer höheren Leistung bei der Softwarebereitstellung.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="Lernkultur">Lernkultur</h3>
+   <p>
+    Etablieren Sie eine Lernkultur und entwickeln Sie ein Verständnis für die Auswirkungen auf Ihre Unternehmensleistung.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="Zufriedenheit am Arbeitsplatz">Zufriedenheit am Arbeitsplatz</h3>
+   <p>
+    Erfahren Sie, wie wichtig es ist, dass Ihre Mitarbeiter über die für ihre Arbeit benötigten Tools und Ressourcen verfügen und ihre Fähigkeiten und Kompetenzen optimal einsetzen können.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="Transformative Führungspositionen">Transformative Führungspositionen</h3>
+   <p>Erfahren Sie, wie effektiv arbeitende Führungskräfte die Leistung der Softwarebereitstellung dadurch beeinflussen, dass sie die Einführung von technischen Funktionen sowie von Produktmanagementfunktionen vorantreiben.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/capabilities.es-419.html
+++ b/misc/additional-translated-content/capabilities.es-419.html
@@ -1,0 +1,289 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>Capacidades de DevOps</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="refresh_date" value="2019-08-08"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+El equipo de <a href="https://www.devops-research.com/research.html">Investigación y evaluación de DevOps (DORA)</a> identificó y validó un conjunto de capacidades que impulsan una entrega de software más alta y un rendimiento organizativo más alto. En estos artículos, se describe cómo implementar, mejorar y medir estas capacidades.
+
+</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="Capacidades técnicas">Capacidades técnicas</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="Control de versiones">Control de versiones</h3>
+   <p>
+Una guía para implementar las prácticas adecuadas de control de versiones a fin de lograr reproducibilidad y trazabilidad.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="Desarrollo basado en troncales">Desarrollo basado en troncales</h3>
+   <p>
+Evita los problemas de conflicto de fusión con prácticas de desarrollo basadas en troncales.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="Integración continua">Integración continua</h3>
+   <p>
+Obtén información sobre errores comunes, formas de medición y cómo mejorar tus esfuerzos de integración continua.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="Automatización de la implementación">Automatización de la implementación</h3>
+   <p>
+Prácticas recomendadas y enfoques para automatizar la implementación y reducir la intervención manual en el proceso de lanzamiento.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="Pruebas continuas">Pruebas continuas</h3>
+   <p>
+Mejora la calidad del software mediante la creación de paquetes de pruebas automatizadas confiables y la ejecución de todo tipo de pruebas durante el ciclo de vida de la entrega de software.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="Entrega continua">Entrega continua</h3>
+   <p>
+Haz que la implementación de software sea un proceso confiable y de bajo riesgo que se pueda realizar a pedido en cualquier momento.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="Arquitectura">Arquitectura</h3>
+   <p>
+Obtén información sobre el paso de una arquitectura con acoplamiento estrecho a arquitecturas orientadas a servicios y microservicios sin volver a diseñar todo de una vez.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="Brinda a los equipos libertad para elegir herramientas">Capacita a los equipos para que elijan herramientas</h3>
+   <p>
+    Capacita a los equipos para que tomen decisiones fundamentadas sobre herramientas y tecnologías. Aprende cómo estas decisiones impulsan una entrega de software más efectiva.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="Administración de datos de pruebas">Administración de datos de pruebas</h3>
+   <p>
+Comprende las estrategias adecuadas de administración de datos de pruebas de manera efectiva junto con los enfoques que proporcionan acceso rápido y seguro a los datos para pruebas.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="Desplazamiento a la izquierda en seguridad">Desplazamiento a la izquierda en seguridad</h3>
+   <p>
+Incorpora la seguridad al ciclo de vida del desarrollo de software sin comprometer la velocidad de la entrega.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="Administración de cambios en la base de datos">Administración de cambios en la base de datos</h3>
+   <p>
+Asegúrate de que los cambios en la base de datos no causen problemas ni retrasos.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="Infraestructura de nube">Infraestructura de nube</h3>
+   <p>
+Obtén información sobre cómo administrar la infraestructura de nube de forma efectiva para lograr niveles más altos de agilidad, disponibilidad y visibilidad de costos.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="Capacidad de mantenimiento del código">Capacidad de mantenimiento del código</h3>
+   <p>
+Haz que los desarrolladores puedan encontrar, volver a usar y cambiar el código con facilidad, y mantener las dependencias actualizadas.
+</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="Capacidades de procesos">Capacidades de procesos</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="Experimentación en equipo">Experimentación en equipo</h3>
+   <p>
+    Realiza innovaciones más rápido mediante la creación de equipos capacitados que puedan probar nuevas ideas sin la aprobación de personas ajenas al equipo.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="Optimiza la aprobación de cambios">Optimiza la aprobación de cambios</h3>
+   <p>
+    Reemplaza los procesos de aprobación de cambios engorrosos por la revisión entre pares para obtener los beneficios de un proceso de lanzamiento más confiable y satisfactorio sin sacrificar la velocidad.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="Comentarios del cliente">Comentarios del cliente</h3>
+   <p>
+    Impulsa mejores resultados organizativos mediante la recopilación de comentarios de los clientes e incorpóralos en el diseño de productos y características.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="Visibilidad del trabajo en la cadena de valor">Visibilidad del trabajo en la cadena de valor</h3>
+   <p>
+    Comprende y visualiza el resultado del flujo de trabajo desde la idea hasta el lanzamiento para impulsar un mayor rendimiento.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="Trabaja en lotes pequeños">Trabaja en lotes pequeños</h3>
+   <p>
+    Crea plazos de entrega más cortos y ciclos de reacción más rápidos mediante el trabajo en lotes pequeños. Obtén información sobre los obstáculos comunes para esta capacidad vital y cómo superarlos.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="Capacidades de medición">Capacidades de medición</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="Sistemas de supervisión para fundamentar las decisiones empresariales">Sistemas de supervisión para fundamentar las decisiones empresariales</h3>
+   <p>
+Mejora la supervisión en las plataformas de infraestructura, middleware y el nivel de aplicación, de modo que puedas proporcionar comentarios rápidos a los desarrolladores.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="Supervisión y observabilidad">Supervisión y observabilidad</h3>
+   <p>
+Obtén información sobre cómo compilar herramientas que te ayuden a comprender y depurar los sistemas de producción.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="Notificación proactiva de fallas">Notificación proactiva de fallas</h3>
+   <p>
+Establece notificaciones proactivas de fallas para identificar problemas vitales y prevenirlos.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="Límites de trabajo en proceso">Límites de trabajo en proceso</h3>
+   <p>
+Prioriza el trabajo, limita la cantidad de elementos en los que se trabaja y enfócate en realizar una pequeña cantidad de tareas de alta prioridad.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="Capacidades de administración visual">Capacidades de administración visual</h3>
+   <p>
+Obtén información sobre los principios de administración visual para promover el intercambio de información, obtener una comprensión común de la situación del equipo y aprender a mejorar.
+</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="Capacidades culturales">Capacidades culturales</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Cultura organizativa de Westrum">Cultura organizativa de Westrum</h3>
+   <p>
+Descubre cómo el crecimiento de una cultura generativa y de alta confianza impulsa un mejor rendimiento organizativo y de entrega de software.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="Cultura del aprendizaje">Cultura del aprendizaje</h3>
+   <p>
+Desarrolla una cultura del aprendizaje y comprende su impacto en el rendimiento de tu organización.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="Satisfacción laboral">Satisfacción laboral</h3>
+   <p>
+Descubre la importancia de garantizar que tu equipo tenga las herramientas y los recursos para hacer su trabajo, y de darles un buen uso a sus habilidades y capacidades.
+</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="Liderazgo transformador">Liderazgo transformador</h3>
+   <p>
+Descubre la forma en que los líderes eficaces impulsan la adopción de capacidades técnicas y de administración de productos para influenciar el rendimiento de la entrega de software.
+</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/capabilities.fr.html
+++ b/misc/additional-translated-content/capabilities.fr.html
@@ -1,0 +1,247 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>Capacités DevOps</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="refresh_date" value="2019-08-08"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+L'équipe de <a href="https://www.devops-research.com/research.html">DORA (DevOps Research and Assessment)</a> a identifié et validé un ensemble de capacités permettant d'optimiser les performances organisationnelles et celles de la livraison de logiciels. Ces articles décrivent comment mettre en œuvre, améliorer et mesurer ces capacités.
+
+</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="Compétences techniques">Compétences techniques</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="Contrôle des versions">Contrôle des versions</h3>
+   <p>Guide de bonnes pratiques pour la mise en œuvre d'un contrôle des versions approprié afin de permettre la reproductibilité et la traçabilité</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="Développement à branche unique">Développement à branche unique</h3>
+   <p>
+    Évitez les problèmes liés aux conflits de fusion en suivant ces pratiques de développement à branche unique.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="Intégration continue">Intégration continue</h3>
+   <p>Découvrez les erreurs fréquentes, les méthodes de mesure et les manières d'améliorer votre intégration continue.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="Automatisation des déploiements">Automatisation des déploiements</h3>
+   <p>Bonnes pratiques et approches permettant d'automatiser les déploiements et de réduire l'intervention manuelle lors du processus de lancement.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="Tests continus">Tests continus</h3>
+   <p>Améliorez la qualité des logiciels en créant des ensembles de tests automatisés et fiables, et en effectuant toutes sortes de tests tout au long du cycle de livraison des logiciels.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="Livraison continue">Livraison continue</h3>
+   <p>Convertissez le déploiement d'un logiciel en un processus fiable et à faible risque pouvant être exécuté à la demande à tout moment.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="Architecture">Architecture</h3>
+   <p>Découvrez comment abandonner une architecture étroitement couplée au profit de modèles d'architecture orientée services ou à base de microservices, sans avoir à modifier toute l'architecture d'un coup.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="Permettre aux équipes de choisir leurs outils">Permettre aux équipes de choisir leurs outils</h3>
+   <p>
+    Permettez à vos équipes de prendre des décisions éclairées sur les outils et les technologies. Découvrez comment ces décisions peuvent optimiser la livraison de logiciels.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="Gestion des données de test">Gestion des données de test</h3>
+   <p>Comprenez quelles stratégies sont les plus adaptées pour gérer efficacement vos données de test, et choisissez une approche permettant de fournir un accès rapide et sécurisé à vos données de test.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="Intégrer la sécurité dès le départ">Intégrer la sécurité dès le départ</h3>
+   <p>Intégrez la sécurité au sein du cycle de vie du développement logiciel sans faire de compromis sur les délais de livraison.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="Gestion du changement de base de données">Gestion du changement de base de données</h3>
+   <p>Assurez-vous que les modifications apportées aux bases de données n'entraînent pas de ralentissements ni de problèmes.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="Infrastructure cloud">Infrastructure cloud</h3>
+   <p>Découvrez comment gérer efficacement votre infrastructure cloud pour atteindre des niveaux supérieurs d'agilité, de disponibilité et de visibilité des coûts.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="Gestion du code">Gestion du code</h3>
+   <p>Facilitez l'accès, la réutilisation et la modification du code ainsi que la mise à jour des dépendances par les développeurs.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="Capacités en termes de processus">Capacités en termes de processus</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="Expérimentation en équipe">Expérimentation en équipe</h3>
+   <p>Bénéficiez d'innovations plus rapides en permettant à vos équipes de s'essayer à de nouvelles idées sans attendre l'approbation de membres extérieurs.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="Simplifier l'approbation des modifications">Optimiser l'approbation des modifications</h3>
+   <p>Ayez recours à des examens par des pairs plutôt qu'à des procédés laborieux d'approbation des modifications. Vous obtiendrez un processus de lancement plus fiable, conforme et tout aussi rapide.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="Commentaires des clients">Commentaires des clients</h3>
+   <p>Obtenez de meilleurs résultats en collectant les retours des clients, et en les incorporant dans la conception de vos produits et fonctionnalités.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="Visibilité du travail dans le flux de valeur">Visibilité du travail dans le flux de valeur</h3>
+   <p>Comprenez et visualisez le flux de travail, de la conceptualisation aux résultats client, afin d'optimiser vos performances.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="Travailler sur de petits volumes">Travailler sur de petits volumes</h3>
+   <p>
+    Accélérez les délais de livraison et les boucles de rétroaction en travaillant par petits lots. Découvrez les obstacles courants liés à cette approche, et les solutions à mettre en place.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="Capacités en termes de mesure">Capacités en termes de mesure</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="Systèmes de surveillance permettant d'éclairer les décisions métier">Systèmes de surveillance permettant d'éclairer les décisions métier</h3>
+   <p>Améliorez la surveillance au niveau des plates-formes, des middlewares et des applications de votre infrastructure afin de fournir des retours rapides aux développeurs.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="Surveillance et observabilité">Surveillance et observabilité</h3>
+   <p>Apprenez à créer des outils pour l'analyse et le débogage des systèmes de production.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="Notification proactive des échecs">Notification proactive des échecs</h3>
+   <p>Mettez en place un système proactif de notification des échecs afin d'identifier les problèmes potentiellement graves et de prendre les mesures nécessaires pour les éviter.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="Limites de travaux en cours">Limitation des tâches</h3>
+   <p>Hiérarchisez le travail, limitez le nombre de tâches de chaque collaborateur et concentrez-vous sur la réalisation d'une petite quantité de tâches à priorité élevée.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="Capacités de gestion visuelle">Capacités de gestion visuelle</h3>
+   <p>Découvrez les principes de la gestion visuelle pour promouvoir le partage d'informations, permettre à l'ensemble de vos collaborateurs de constater l'avancement de l'équipe, et découvrir comment améliorer votre travail.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="Capacités en termes de culture">Capacités en termes de culture</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Culture organisationnelle Westrum">Culture organisationnelle Westrum</h3>
+   <p>
+    Découvrez comment améliorer les performances de votre organisation et de la livraison de logiciels en développant une culture générative basée sur une grande confiance.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="Culture d'apprentissage">Culture d'apprentissage</h3>
+   <p>
+    Développez une culture d'apprentissage et constatez son impact sur les performances de votre organisation.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="Satisfaction professionnelle">Satisfaction professionnelle</h3>
+   <p>
+    Réalisez à quel point il est important de donner les bons outils et ressources à vos collaborateurs, et de mettre à profit leurs connaissances et compétences.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="Leadership de la transformation">Leadership de la transformation</h3>
+   <p>Découvrez en quoi les responsables efficaces influencent les performances de livraison des logiciels en favorisant l'adoption de nouvelles capacités techniques et de gestion des produits.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/capabilities.ja.html
+++ b/misc/additional-translated-content/capabilities.ja.html
@@ -1,0 +1,235 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>DevOps の能力</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="refresh_date" value="2019-08-08"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+<a href="https://www.devops-research.com/research.html">DevOps Research and Assessment（DORA）</a>チームが、ソフトウェア デリバリーと組織のパフォーマンスを改善するための能力を調査し、検証しています。以下の記事では、これらの能力の実装、改善、測定方法について説明します。</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="技術に関する能力">技術に関する能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="バージョン管理">バージョン管理</h3>
+   <p>再現性とトレーサビリティの確保に向け、適切なバージョン管理を実現するためのガイドです。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="トランクベース開発">トランクベース開発</h3>
+   <p>トランクベース開発を採用することでマージの競合を回避します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="継続的インテグレーション">継続的インテグレーション</h3>
+   <p>継続的インテグレーションの取り組みに関し、よくある間違い、測定方法、改善方法をご紹介します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="デプロイの自動化">デプロイの自動化</h3>
+   <p>デプロイを自動化し、リリース プロセスにおける手動作業を減らすためのベスト プラクティスとアプローチをご紹介します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="継続的なテスト">継続的なテスト</h3>
+   <p>信頼性の高い自動テストスイートを構築し、ソフトウェア配信ライフサイクル全体であらゆる種類のテストを行うことで、ソフトウェアの品質を向上させます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="継続的デリバリー">継続的デリバリー</h3>
+   <p>ソフトウェアのデプロイを必要に応じていつでも実施できる、信頼性が高く、リスクの低いプロセスにします。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="アーキテクチャ">アーキテクチャ</h3>
+   <p>一度にすべてを再構築せずに、緊密に結合されたアーキテクチャからサービス指向型のマイクロサービス アーキテクチャに移行する方法を説明します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="チームのツール選択をサポート">チームのツール選択をサポート</h3>
+   <p>
+    ツールとテクノロジーの選択について、チームが情報に基づいた判断ができるようにサポートします。これにより、どのようにソフトウェアのデリバリーが効率化されるかを説明します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="テストデータ管理">テストデータ管理</h3>
+   <p>テストデータを効率的に管理するための方法について説明します。高速で安全にテスト用データにアクセスするための方法も併せてご紹介します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="セキュリティのシフトレフト">セキュリティのシフトレフト</h3>
+   <p>ソフトウェアのデリバリー スピードを落とさずに、セキュリティをソフトウェアの開発ライフサイクルに組み込みます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="データベースのチェンジ マネジメント">データベースのチェンジ マネジメント</h3>
+   <p>データベースの変更によって問題や速度低下が発生していないか確認します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="クラウド インフラストラクチャ">クラウド インフラストラクチャ</h3>
+   <p>クラウド インフラストラクチャを効果的に管理する方法を把握し、アジリティ、可用性、費用の可視性を高めます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="コードの保守性">コードの保守性</h3>
+   <p>デベロッパーがコードの検索、再利用、変更を簡単に行えるようにし、依存関係を最新の状態に保ちます。</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="プロセスに関する能力">プロセスに関する能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="チームのテスト">チームのテスト</h3>
+   <p>チーム外の担当者からの承認を得ずに、新たなアイデアを試す権限を持つチームを作ることでイノベーションを加速します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="変更承認の効率化">変更承認の効率化</h3>
+   <p>負荷の大きな変更承認プロセスをピアレビューに置き換えることで、プロセスのスピードを犠牲にすることなく、信頼性とコンプライアンスに優れたリリース プロセスのメリットが得られます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="お客様のフィードバック">お客様のフィードバック</h3>
+   <p>お客様からのフィードバックをまとめ、プロダクトと機能の設計に生かすことで、組織の改善がさらに進みます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="バリュー ストリームでの作業の可視性">バリュー ストリームでの作業の可視性</h3>
+   <p>アイデアから始まり顧客成果に至るまでの作業の流れを把握、可視化することで、パフォーマンスを改善します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="小さいバッチ単位の作業">小さいバッチ単位の作業</h3>
+   <p>
+    小さいバッチ単位での作業は、リードタイムの短縮とフィードバック ループの高速化につながります。この重要な機能の実現を阻害するよくある問題と、それらを克服する方法についてご紹介します。</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="測定に関する能力">測定に関する能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="システムをモニタリングして的確な判断">システムをモニタリングして的確な判断</h3>
+   <p>インフラストラクチャ プラットフォーム、ミドルウェア、アプリケーション階層全体のモニタリングを改善し、デベロッパーにフィードバックをより早く提供します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="モニタリングとオブザーバビリティ">モニタリングとオブザーバビリティ</h3>
+   <p>本番環境システムを理解してデバッグする際に有用なツールを構築する方法を学びます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="障害の予兆通知">障害の予兆通知</h3>
+   <p>障害の予兆通知を設定することで重大な問題を特定し、問題が起きる前に対処できます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="仕掛り制限">仕掛り制限</h3>
+   <p>作業に優先順位を付け、スタッフが取り組む作業量を制限し、少数の優先度の高いタスクを完了することに注力します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="ビジュアル管理機能">ビジュアル管理機能</h3>
+   <p>ビジュアル管理の原則について学び、情報の共有を促進してチームの状況と改善方法に関し共通の認識を持ちます。</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="文化に関する能力">文化に関する能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Westrum の組織類型">Westrum の組織類型</h3>
+   <p>強い信頼関係と情報の流れを重視する組織文化が、ソフトウェア デリバリーにおいてどのように良い結果をもたらしているかご紹介します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="学習文化">学習文化</h3>
+   <p>学習文化を浸透させることで、組織のパフォーマンスに好影響がもたらされます。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="仕事の満足度">仕事の満足度</h3>
+   <p>仕事に使えるツールとリソース、自分のスキルと能力を発揮できる環境が整っていることの重要性についてご紹介します。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="変革型リーダーシップ">変革型リーダーシップ</h3>
+   <p>効果的なリーダーシップで技術的および製品管理上の変革を推進することで、ソフトウェア配信のパフォーマンスがどのように変化するのかを学びます。</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/capabilities.ko.html
+++ b/misc/additional-translated-content/capabilities.ko.html
@@ -1,0 +1,247 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>DevOps 기능</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="refresh_date" value="2019-08-08"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+<a href="https://www.devops-research.com/research.html">DevOps 연구 및 평가(DORA)</a> 팀은 소프트웨어 제공 및 조직 성과 향상을 가져오는 기능 집합을 식별하고 검증했습니다. 이 문서에서는 이러한 기능을 구현, 개선, 측정하는 방법을 설명합니다.
+
+</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="기술적 기능">기술적 역량</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="버전 제어">버전 제어</h3>
+   <p>재현성과 추적 가능성을 충족하는 데 필요한 버전 제어 방법을 구현하도록 안내합니다.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="트렁크 기반 개발">트렁크 기반 개발</h3>
+   <p>
+    트렁크 기반 개발 방법으로 병합 충돌 문제를 방지하세요.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="지속적 통합">지속적 통합</h3>
+   <p>일반적인 실수, 측정 방법, 지속적 통합 작업의 개선 방법에 대해 알아보세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="배포 자동화">배포 자동화</h3>
+   <p>배포 자동화와 출시 절차 중의 수동 개입 축소를 위한 권장사항 및 접근 방식을 소개합니다.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="지속적 테스트">지속적 테스트</h3>
+   <p>안정적인 자동화 테스트 모음을 빌드하고 소프트웨어 제공 수명 주기 전반에 걸쳐 모든 종류의 테스트를 수행하여 소프트웨어 품질을 향상시킵니다.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="지속적 배포">지속적 배포</h3>
+   <p>소프트웨어 배포 작업을 언제든지 필요에 따라 수행할 수 있는 신뢰할 수 있고 위험이 낮은 프로세스로 만듭니다.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="아키텍처">아키텍처</h3>
+   <p>한 번에 모든 것을 다시 설계하지 않고도 긴밀하게 연결된 아키텍처에서 서비스 지향 마이크로서비스 아키텍처로 이전하는 방법에 대해 알아보세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="팀의 도구 선택을 지원">팀의 도구 선택을 지원</h3>
+   <p>
+    팀이 도구와 기술을 결정할 때 정보에 입각해 판단할 수 있도록 지원하세요. 이러한 의사결정으로 소프트웨어 제공의 효과를 높일 수 있는 방법을 알아보세요.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="테스트 데이터 관리">테스트 데이터 관리</h3>
+   <p>테스트 데이터를 효과적으로 관리하기 위한 전략과 테스트를 위해 데이터에 빠르고 안전하게 액세스할 수 있는 접근 방식에 대해 알아보세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="개발 초기부터 보안 문제 반영">개발 초기부터 보안 문제 반영</h3>
+   <p>제공 속도의 저하 없이 소프트웨어 개발 수명 주기에 보안을 통합하세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="데이터베이스 변경 관리">데이터베이스 변경 관리</h3>
+   <p>데이터베이스 변경으로 인해 문제가 발생하거나 속도가 느려지지 않도록 합니다.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="클라우드 인프라">클라우드 인프라</h3>
+   <p>더 높은 수준의 민첩성, 가용성, 비용 가시성을 얻을 수 있도록 클라우드 인프라를 효과적으로 관리하는 방법을 찾습니다.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="코드 유지관리성">코드 유지관리성</h3>
+   <p>개발자가 코드를 쉽게 찾아서, 재사용 및 변경하고, 종속 항목을 최신 상태로 유지할 수 있게 해줍니다.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="프로세스 기능">프로세스 기능</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="팀 실험">팀 실험</h3>
+   <p>팀 외부 관계자의 승인 없이도 새 아이디어를 시험해 볼 수 있는 자율적인 팀을 구축하여 빠른 혁신을 이루세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="변경 승인 간소화">변경 승인 간소화</h3>
+   <p>상부 변경-승인 절차를 동료 검토로 대체해 속도의 저하 없이 규정을 준수한 안정적인 출시 절차를 활용해 보세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="고객 의견">고객 의견</h3>
+   <p>고객 의견을 수집해 제품 및 기능 설계에 반영하여 보다 우수한 조직 성과를 얻으세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="가치 흐름에서의 작업 가시성">가치 흐름에서의 작업 가시성</h3>
+   <p>아이디어 구상부터 고객 결과에 이르는 업무 흐름을 이해하고 시각화하여 더욱 우수한 성과를 얻으세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="소규모 배치로 작업">소규모 배치로 작업</h3>
+   <p>
+    소규모 배치 작업으로 리드 타임을 단축하고 피드백 루프 속도를 높이세요. 이 중요한 기능의 일반적인 문제와 해결 방법에 대해 알아보세요.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="측정 기능">측정 기능</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="비즈니스 의사 결정용 모니터링 시스템">비즈니스 의사 결정용 모니터링 시스템</h3>
+   <p>인프라 플랫폼, 미들웨어, 애플리케이션 계층의 모니터링을 개선하여 개발자에게 빠른 피드백을 제공하세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="모니터링 및 관측 가능성">모니터링 및 관측 가능성</h3>
+   <p>프로덕션 시스템을 이해하고 디버그하는 데 도움이 되는 도구를 빌드하는 방법을 알아보세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="오류 사전 알림">오류 사전 알림</h3>
+   <p>오류 사전 알림을 설정하여 중요한 문제를 식별하고 문제 발생 전에 조치를 취하세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="진행 중인 업무 한도">진행 중인 업무 한도</h3>
+   <p>업무 우선순위를 지정하고 작업량을 제한하여 우선순위가 높은 소량의 업무를 완료하는 데 집중하세요.</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="시각적 관리 기능">시각적 관리 기능</h3>
+   <p>시각적 관리 원칙을 통해 정보 공유를 촉진하고 팀 업무 현황에 대한 공통의 이해를 얻으며 개선 방법을 파악하세요.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="문화적 기능">문화적 기능</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Westrum 조직 문화">Westrum 조직 문화</h3>
+   <p>
+    신뢰하는 생성적 문화의 성장으로 어떻게 조직 성과와 소프트웨어 제공 성능을 높일 수 있는지 알아보세요.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="학습 문화">학습 문화</h3>
+   <p>
+    학습 문화를 조성하고 학습 문화가 조직 성과에 미치는 영향에 대해 알아보세요.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="직무 만족도">직무 만족도</h3>
+   <p>
+    인력이 업무에 필요한 도구와 리소스를 확보하고 기술과 역량을 충분히 활용하는 것이 얼마나 중요한지 알아보세요.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="혁신적인 리더십">혁신적인 리더십</h3>
+   <p>효과적인 혁신 리더가 기술 및 제품 관리 기능 도입을 촉진하여 소프트웨어 제공 성능에 어떤 영향을 줄 수 있는지 알아보세요.</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/capabilities.pt-br.html
+++ b/misc/additional-translated-content/capabilities.pt-br.html
@@ -1,0 +1,312 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>Recursos de DevOps</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+A equipe <a href="https://www.devops-research.com/research.html">DevOps Research and Assessment (DORA)</a> identificou e validou um conjunto de recursos que aumentam o fornecimento de software e o desempenho organizacional. Nestes artigos, descrevemos como implementar, melhorar e medir esses recursos.
+
+</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="Habilidades técnicas">Habilidades técnicas</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="Controle de versão">Controle de versão</h3>
+   <p>
+    Um guia para implementar as práticas corretas de controle de versões para
+    reprodutibilidade e rastreabilidade.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="Desenvolvimento baseado em troncos">Desenvolvimento baseado em troncos</h3>
+   <p>
+    Evite problemas na mesclagem com práticas de desenvolvimento baseadas em tronco.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="Integração contínua">Integração contínua</h3>
+   <p>
+    Aprenda sobre erros comuns, maneiras de medir e como melhorar seus
+    esforços de integração contínua.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="Automação de implantação">Automação de implantação</h3>
+   <p>
+    Práticas recomendadas e abordagens para automação de implantação e redução da
+    intervenção manual no processo de lançamento.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="Teste contínuo">Teste contínuo</h3>
+   <p>
+    Melhore a qualidade do software criando conjuntos de testes automatizados confiáveis e
+    executando todos os tipos de testes durante o ciclo de vida de entrega de software.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="Entrega contínua">Entrega contínua</h3>
+   <p>
+    Torne a implantação de software um processo confiável e de baixo risco que possa ser realizado
+    sob demanda a qualquer momento.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="Arquitetura">Arquitetura</h3>
+   <p>
+    Aprenda a migrar de uma arquitetura fortemente acoplada para uma orientada por
+    serviços e microsserviços sem precisar remodelar tudo de uma vez.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="Como capacitar equipes a escolher ferramentas">Como dar autonomia às equipes para que escolham ferramentas</h3>
+   <p>
+    Dê autonomia às equipes para que tomem decisões informadas sobre ferramentas e tecnologias. Saiba
+    como essas decisões geram uma entrega de software mais eficaz.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="Gerenciamento de dados de teste">Gerenciamento de dados de teste</h3>
+   <p>
+    Entenda as estratégias corretas para gerenciar dados de teste de maneira eficaz e conheça
+    abordagens que fornecem acesso rápido e seguro aos dados para testes.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="Como integrar a segurança aos processos">Como integrar a segurança aos processos</h3>
+   <p>
+    Incorpore segurança ao ciclo de vida de desenvolvimento do software sem
+    comprometer a velocidade de entrega.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="Gerenciamento de mudanças no banco de dados">Gerenciamento de mudanças no banco de dados</h3>
+   <p>
+    Verifique se as alterações no banco de dados não causam problemas nem deixam você lento.
+
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="Infraestrutura em nuvem">Infraestrutura em nuvem</h3>
+   <p>
+    Descubra como gerenciar a infraestrutura em nuvem com eficiência para alcançar
+    níveis mais altos de agilidade, disponibilidade e visibilidade de custos.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="Capacidade de manutenção de código">Capacidade de manutenção de código</h3>
+   <p>
+    Facilite a localização, a reutilização e a alteração do código para que os
+    desenvolvedores mantenham as dependências atualizadas.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="Recursos do processo">Recursos do processo</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="Experimentação da equipe">Experimentação da equipe</h3>
+   <p>
+    Inove mais rapidamente criando equipes capacitadas que podem testar novas ideias
+    sem a aprovação de pessoas de fora da equipe.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="Como otimizar a aprovação de alterações">Como otimizar a aprovação de alterações</h3>
+   <p>
+    Substitua os processos trabalhosos de aprovação de alterações pela avaliação pelos pares e alcance os
+    benefícios de um processo de liberação mais confiável e em conformidade, sem sacrificar
+    a velocidade.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="Feedback do cliente">Feedback dos clientes</h3>
+   <p>
+    Gere melhores resultados organizacionais reunindo o feedback dos clientes e
+    incorporando-o ao design de produtos e recursos.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="Visibilidade de trabalho no fluxo de valor">Visibilidade de trabalho no fluxo de valor</h3>
+   <p>
+    Entenda e visualize o fluxo de trabalho desde a criação até o resultado
+    para o cliente a fim de conseguir um melhor desempenho.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="Como trabalhar em lotes pequenos">Como trabalhar em lotes pequenos</h3>
+   <p>
+    Crie prazos de entrega mais curtos e loops de feedback mais rápidos trabalhando em pequenos
+    lotes. Conheça os obstáculos comuns a esse recurso essencial e aprenda a
+    superá-los.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="Recursos de avaliação">Recursos de avaliação</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="Como monitorar sistemas para informar decisões de negócios">Como monitorar sistemas para informar decisões de negócios</h3>
+   <p>
+    Melhore o monitoramento em plataformas de infraestrutura, middleware e no nível
+    do aplicativo para poder fornecer feedback rápido aos desenvolvedores.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="Monitoramento e observabilidade">Monitoramento e observabilidade</h3>
+   <p>
+    Aprenda a criar ferramentas para entender e depurar melhor seus
+    sistemas de produção.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="Notificação proativa de falhas">Notificação proativa de falhas</h3>
+   <p>
+    Implemente notificações proativas de falha para identificar problemas graves e agir
+antes que venham à tona.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="Limites do trabalho em processo">Limites do trabalho em processo</h3>
+   <p>
+    Priorize o trabalho, limite a quantidade de trabalho das pessoas
+    e concentre-se em realizar um pequeno número de tarefas de alta prioridade.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="Recursos de gerenciamento visual">Recursos de gerenciamento visual</h3>
+   <p>
+    Aprenda os princípios do gerenciamento visual para promover o compartilhamento de informações
+    e gerar um entendimento comum do andamento do trabalho da equipe e como melhorá-lo.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="Capacidades culturais">Capacidades culturais</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Cultura organizacional de Westrum">Cultura organizacional de Westrum</h3>
+   <p>
+    Descubra como desenvolver uma cultura generativa e de alta confiança gera um melhor desempenho organizacional e de entrega de software.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="Cultura de aprendizado">Cultura de aprendizado</h3>
+   <p>
+    Desenvolva uma cultura de aprendizado e entenda seu impacto no desempenho organizacional.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="Satisfação no trabalho">Satisfação no trabalho</h3>
+   <p>
+    Descubra como é importante garantir que sua equipe tenha as ferramentas e os recursos necessários para suas funções, além de fazer bom uso de suas habilidades.
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="Liderança transformacional">Liderança transformacional</h3>
+   <p>
+    Saiba como líderes eficientes influenciam o desempenho de entrega de software impulsionando a adoção de recursos técnicos e de gerenciamento de produtos.
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/capabilities.zh-cn.html
+++ b/misc/additional-translated-content/capabilities.zh-cn.html
@@ -1,0 +1,278 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>DevOps 能力</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+    <meta name="keywords" value="category:DevOps,docType:Concept,dora"/>
+    <meta name="refresh_date" value="2019-08-08"/>
+    <meta name="hide_last_updated" value="true"/>
+
+        <meta name="gtm_var" data-key="docType" data-value="landing"/>
+    <meta name="translation_service" value="machine_translation_light_post_edit"/>
+  </head>
+  <body>
+
+      <span class="notranslate">{% dynamic setvar launch_name %}DevOps{% dynamic endsetvar %}</span>
+
+    <article id="cloud-site" class="grid-fluid l-fixed-width">
+      <section class="l-relative">
+        <div class="grid-fluid">
+          <div class="c12">
+
+<p>
+
+<a href="https://www.devops-research.com/research.html">DevOps 研究和评估 (DORA)</a> 团队已确定和验证一组推动实现更出色的软件交付表现和组织绩效的能力。这些文章介绍如何实现、改进和衡量这些能力。</p>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="technical-capabilities" data-text="技术能力">技术能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-tech-version-control" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="version-control" data-text="版本控制">版本控制</h3>
+   <p>
+    指导如何实施正确的版本控制做法来确保可再现性和可追溯性。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-trunk-based-development" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="trunk-based-development" data-text="主干开发">主干开发</h3>
+   <p>
+    借助主干开发做法，避免合并冲突困扰。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-integration" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-integration" data-text="持续集成">持续集成</h3>
+   <p>
+    了解常见错误、评估方法以及如何改进持续集成工作。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-deployment-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="deployment-automation" data-text="部署自动化">部署自动化</h3>
+   <p>
+    部署自动化和减少发布过程人工干预的最佳做法与方法。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-automation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-testing" data-text="持续测试">持续测试</h3>
+   <p>构建可靠的自动化测试套件并在软件交付生命周期中执行各种测试，从而提高软件质量。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-continuous-delivery" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="continuous-delivery" data-text="持续交付">持续交付</h3>
+   <p>
+    使部署软件成为可靠、低风险、可随时按需执行的过程。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-architecture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="architecture" data-text="架构">架构</h3>
+   <p>
+    了解如何从紧密耦合的架构迁移到面向服务的微服务架构，而无需立即重新设计一切。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-teams-empowered-to-choose-tools" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="empowering-teams-to-choose-tools" data-text="赋予团队选择工具的能力">赋予团队选择工具的能力</h3>
+   <p>
+    为团队赋能，让他们能够围绕工具和技术做出明智的决策。了解这些决策如何推动实现更有效的软件交付。</p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-test-data-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="test-data-management" data-text="测试数据管理">测试数据管理</h3>
+   <p>
+    了解有效管理测试数据的正确策略，以及为测试提供快速、安全的数据访问权限的方法。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-shifting-left-on-security" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="shifting-left-on-security" data-text="更早将安全性纳入软件开发流程">更早将安全性纳入软件开发流程</h3>
+   <p>
+    在不影响交付速度的前提下将安全性植入软件开发生命周期。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-database-change-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="database-change-management" data-text="数据库更改管理">数据库更改管理</h3>
+   <p>确保数据库更改不会导致问题或拖慢您的速度。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-cloud-infrastructure" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="cloud-infrastructure" data-text="云基础架构">云基础架构</h3>
+   <p>了解如何有效管理云基础架构，以实现更高的敏捷性、可用性和费用可见性。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-tech-code-maintainability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="code-maintainability" data-text="代码可维护性">代码可维护性</h3>
+   <p>让开发者能够轻松查找、重复使用和更改代码，并使依赖项保持最新。
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="process-capabilities" data-text="流程能力">流程能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-process-team-experimentation" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="team-experimentation" data-text="团队实验">团队实验</h3>
+   <p>
+    构建具有必要权力的团队，使他们无需征得团队以外人员的批准即可尝试新的创意，更快地开展创新。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-streamlining-change-approval" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="streamlining-change-approval" data-text="简化变更审核流程">简化变更审核流程</h3>
+   <p>
+    用代码互审代替繁杂的变更审批流程，在不影响速度的情况下获享更可靠、合规的发布流程的优势。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-customer-feedback" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="customer-feedback" data-text="客户反馈">客户反馈</h3>
+   <p>
+    收集客户反馈并将其融入产品和功能设计中，以推动实现更出色的组织成效。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-work-visibility-in-value-stream" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visibility-of-work-in-the-value-stream" data-text="价值流中工作的可视性">价值流中工作的可视性</h3>
+   <p>
+    直观了解从创意到客户成效的工作流，实现更出色的表现。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-process-working-in-small-batches" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="working-in-small-batches" data-text="小批量工作方式">小批量工作方式</h3>
+   <p>
+    小批量工作方式可缩短准备时间并加快反馈循环。了解这项关键能力常遇到的障碍以及如何加以克服。</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="measurement-capabilities" data-text="测量能力">测量能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-systems" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-systems-to-inform-business-decisions" data-text="监控系统以做出明智的业务决策">监控系统以做出明智的业务决策</h3>
+   <p>
+    提升对基础架构平台、中间件和应用层的监控性能，让您可以向开发者快速提供反馈。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-monitoring-and-observability" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="monitoring-and-observability" data-text="监控和可观测性">监控和可观测性</h3>
+   <p>
+    了解如何构建工具以帮助您了解和调试生产系统。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-proactive-failure-notification" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="proactive-failure-notification" data-text="主动式故障通知">主动式故障通知</h3>
+   <p>
+    设置主动式故障通知，以识别重大问题并在问题出现之前解决隐患。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-wip-limits" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="work-in-process-limits" data-text="进行中工作数限制">进行中工作数限制</h3>
+   <p>
+    确定工作的优先级，限制人们同时处理的工作量，集中精力完成少量优先级高的任务。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-measurement-visual-management" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="visual-management-capabilities" data-text="目视管理能力">目视管理能力</h3>
+   <p>了解目视管理的原则，以促进信息共享，同时取得对团队的状况以及如何提升的共识。
+    </p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+<div class="card" id="concepts">
+  <header>
+   <h2 id="cultural-capabilities" data-text="文化能力">文化能力</h2>
+  </header>
+  <ul class="card-showcase">
+
+<li>
+  <a href="/architecture/devops/devops-culture-westrum-organizational-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="westrum-organizational-culture" data-text="Westrum 组织文化">Westrum 组织文化</h3>
+   <p>
+    了解培养信任度高的生成文化如何推动实现更出色的组织表现和软件交付性能。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-learning-culture" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="learning-culture" data-text="学习文化">学习文化</h3>
+   <p>
+    培养学习文化，并理解它对组织表现的影响。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-job-satisfaction" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="job-satisfaction" data-text="工作满意度">工作满意度</h3>
+   <p>
+    了解确保您的员工拥有执行工作所需的工具和资源以及充分利用其技术和能力的重要性。
+    </p>
+  </a>
+</li>
+<li>
+  <a href="/architecture/devops/devops-culture-transformational-leadership" class="no-logo">
+    <h3 class="hide-from-toc no-link" id="transformational-leadership" data-text="变革型领导力">变革型领导力</h3>
+   <p>了解如何推动采用技术和产品管理功能以有效提高领导在软件交付表现方面的影响力。</p>
+  </a>
+</li>
+
+  </ul>
+</div>
+
+          </div>
+
+        </div>
+      </section>
+    </article>
+
+</body></html>

--- a/misc/additional-translated-content/devops-four-key-metrics.fr.html
+++ b/misc/additional-translated-content/devops-four-key-metrics.fr.html
@@ -1,0 +1,81 @@
+<html devsite><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title>Quatre métriques clés</title>
+    <meta name="book_path" value="/architecture/devops/_book.yaml"/>
+    <meta name="project_path" value="/architecture/devops/_project.yaml"/>
+  </head>
+  <body>
+
+<p>Vitesse et stabilité</p>
+
+<p>Quatre métriques clés</p>
+
+<ul>
+<li><strong>Délai d'affichage des modifications</strong> : délai entre le moment où le code est validé dans un système de contrôle des versions et le moment où ce code est disponible pour les utilisateurs.</li>
+<li><strong>Fréquence de déploiement</strong> : fréquence à laquelle les modifications sont transmises à l'environnement de production.</li>
+<li><strong>Temps de restauration du service</strong> : temps nécessaire à la récupération complète après un incident ou une panne.</li>
+<li><strong>Taux d'échec des modifications</strong> : pourcentage de modifications en production ayant échoué.</li>
+</ul>
+
+<table>
+  <colgroup><col width="40%" />
+  <col width="15%" />
+  <col width="15%" />
+  <col width="15%" />
+  <col width="15%" />
+  </colgroup><thead>
+    <tr>
+      <th>Aspect des performances de livraison de logiciels</th>
+      <th>Elite</th>
+      <th>Élevé</th>
+      <th>Moyen</th>
+      <th>Faible</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><p><b>Fréquence de déploiement</b></p>
+      <p>Pour l'application ou le service principal sur lequel vous travaillez, à quelle fréquence votre organisation déploie-t-elle du code en production ou le rend-t-elle accessible aux utilisateurs finaux ?</p></td>
+    <td><p>À la demande (plusieurs déploiements par jour)</p></td>
+    <td><p>Entre une fois par jour et une fois par semaine</p>
+    </td><td><p>Entre une fois par semaine et une fois par mois</p></td>
+    <td><p>Entre une fois par mois et une fois tous les six mois</p>
+    </td>
+  </tr>
+   <tr>
+     <td><p><b>Délai de livraison des modifications</b></p>
+       <p>Pour l'application ou le service principal sur lequel vous travaillez, quel est votre délai de livraison des modifications (à savoir, combien de temps faut-il pour passer du code validé au code en production) ?</p></td>
+    <td><p>Moins d'un jour</p></td>
+    <td><p>Entre un jour et une semaine</p>
+    </td><td><p>Entre une semaine et un mois</p></td>
+    <td><p>Entre un mois et six mois</p>
+    </td>
+  </tr>
+  <tr>
+    <td><p><b>Délai de restauration du service</b></p>
+      <p>En ce qui concerne l'application ou le service principal sur lequel vous travaillez, combien de temps faut-il pour restaurer un service en cas d'incident ou de défaut qui affecte les utilisateurs (par exemple, en cas de panne imprévue ou d'interruption du service) ?</p></td>
+    <td><p>Moins d'une heure</p></td>
+    <td><p>Moins d'un jour</p>
+    </td><td><p>Moins d'un jour</p></td>
+    <td><p>Entre une semaine et un mois</p>
+    </td>
+  </tr>
+  <tr>
+    <td><p><b>Modifier le taux d'échec</b></p>
+      <p>En ce qui concerne l'application ou le service principal sur lequel vous travaillez, quel pourcentage de modifications en production ou mises à la disposition des utilisateurs entraîne une dégradation du service (par exemple, une interruption ou une panne du service) et nécessite par conséquent une correction (application de correctifs, rollback, fix forward, patch) ?</p></td>
+    <td><p>0-15 %</p></td>
+    <td><p>0-15 %</p>
+    </td><td><p>0-15 %</p></td>
+    <td><p>46-60 %</p>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+<h2 id="whats_next" data-text="Étape suivante" tabindex="0">Étapes suivantes</h2>
+
+<ul>
+<li>Découvrez notre <a href="https://www.devops-research.com/research.html">programme de recherche</a> DevOps.</li>
+<li>Passez notre <a href="https://www.devops-research.com/quickcheck.html">évaluation DevOps rapide</a> pour comprendre où vous vous situez par rapport au reste du secteur.</li>
+</ul>
+
+</body></html>


### PR DESCRIPTION
I found a handful of additional—previously deleted—content that may be of use.

(The `devops-four-key-metrics` file appears to only exist in `fr`. Searching through the Google repo didn't reveal any additional translations of that.)