### PR TITLE
ignore README.md on hugo build

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -12,3 +12,10 @@ unsafe= true
   changefreq = 'monthly'
   filename = 'sitemap.xml'
   priority = 0.5
+
+[[cascade]]
+  [cascade._target]
+    path = "**/README.md"
+  [cascade._build]
+    render = "never"
+    list = "never"


### PR DESCRIPTION
Currently, the Hugo build process treats `README.md` as a content file and builds it into the content hierarchy. I think it's more intuitive to assume that README.md contains developer documentation, which may live alongside content files. In that case, it shouldn't be built—this PR adds configuration to Hugo so that README.md files won't be built.