### PR TITLE
Re-enable Extension Infra as Code

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -21,7 +21,7 @@
   "etags": {
     "doradotdev-staging": {
       "extensionInstances": {
-        "firestore-send-email": "cef271def8b9c29491c2d27fd15472452515f5b3834421efac1015c3dd06205f"
+        "firestore-send-email": "e454c6869b1d6c05ac318fc9347178c13b457fa22f299f7e70fd49a1b324880e"
       }
     },
     "doradotdev": {

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -24,4 +24,4 @@ steps:
     env:
       - 'PROJECT_ID=$PROJECT_ID'
     script: |
-      firebase deploy --non-interactive --except=extensions --project=${PROJECT_ID}
+      firebase deploy --non-interactive --project=${PROJECT_ID}

--- a/ci/preview-infra.cloudbuild.yaml
+++ b/ci/preview-infra.cloudbuild.yaml
@@ -42,4 +42,4 @@ steps:
       # so we'll skip the extension until that's fixed
 
       # skip remote config
-      firebase deploy --non-interactive --project=${PROJECT_ID} --except=extensions,remoteconfig
+      firebase deploy --non-interactive --project=${PROJECT_ID} --except=remoteconfig

--- a/ci/preview-infra.cloudbuild.yaml
+++ b/ci/preview-infra.cloudbuild.yaml
@@ -37,9 +37,5 @@ steps:
       apt update && apt install curl sudo -y
       curl -sL https://firebase.tools | bash
 
-      # BUG: there is a bug in Firebase that is causing issues when installing the extension on staging
-      # see: https://github.com/firebase/firebase-tools/issues/6060
-      # so we'll skip the extension until that's fixed
-
       # skip remote config
       firebase deploy --non-interactive --project=${PROJECT_ID} --except=remoteconfig

--- a/extensions/firestore-send-email.env.doradotdev
+++ b/extensions/firestore-send-email.env.doradotdev
@@ -2,6 +2,6 @@ DEFAULT_FROM=DORA.DEV Inquiry <no-reply@dora.dev>
 LOCATION=us-east1
 MAIL_COLLECTION=email-log
 SMTP_CONNECTION_URI=smtps://team@dora.dev@smtp.gmail.com:465
-SMTP_PASSWORD=projects/712907887884/secrets/ext-firestore-send-email-SMTP_PASSWORD-dxq/versions/latest
+SMTP_PASSWORD=projects/${param:PROJECT_NUMBER}/secrets/ext-firestore-send-email-SMTP_PASSWORD-dxq/versions/latest
 TTL_EXPIRE_TYPE=day
 TTL_EXPIRE_VALUE=63

--- a/extensions/firestore-send-email.env.doradotdev-staging
+++ b/extensions/firestore-send-email.env.doradotdev-staging
@@ -2,6 +2,6 @@ DEFAULT_FROM=[TEST] STAGING.DORA.DEV Inquiry <no-reply@dora.dev>
 LOCATION=us-east1
 MAIL_COLLECTION=email-log
 SMTP_CONNECTION_URI=smtps://team@dora.dev@smtp.gmail.com:465
-SMTP_PASSWORD=projects/280168604467/secrets/ext-firestore-send-email-SMTP_PASSWORD-dxq/versions/latest
+SMTP_PASSWORD=projects/${param:PROJECT_NUMBER}/secrets/ext-firestore-send-email-SMTP_PASSWORD-dxq/versions/latest
 TTL_EXPIRE_TYPE=day
 TTL_EXPIRE_VALUE=63


### PR DESCRIPTION
Re-enabled Email extension to be managed as Infra as Code via `firebase deploy`

Upon PR Merge, this will impact production as `firebase deploy` is leveraged for production 