### PR TITLE
Add additional redirect for "DORA joins Google Cloud" page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -45,6 +45,11 @@
           "type": 301
         },
         {
+          "source": "/2018/12/dora-joins-google-cloud/",
+          "destination": "/news/dora-joins-google-cloud/",
+          "type": 301
+        },        
+        {
             "source": "/core",
             "destination": "/research/",
             "type": 302


### PR DESCRIPTION
We've discovered there are additional links in the wild pointing to a different variant of the "DORA joins Google Cloud" link. This PR adds another redirect for that other url.