### PR TITLE
change headline on homepage

### DIFF
--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -2,7 +2,7 @@
 title: "DevOps Research and Assessment"
 date: 2022-11-22
 draft: false
-bannerTitle: "DevOps Research and Assessment"
+bannerTitle: "Get Better at Getting Better"
 bannerSubtitle: "DevOps Research and Assessment (DORA) is the largest and longest running research program of its kind, that seeks to understand the capabilities that drive software delivery and operations performance. DORA helps teams apply those capabilities, leading to better organizational performance."
 stylesheets:
     - name: "homepage"


### PR DESCRIPTION
This PR replaces the homepage headline with "Get Better at Getting Better" -- a more emotive/call-to-action sort of thing. DORA has used this phrase in various contexts and it resonates with people.