### PR TITLE
Add 2022 report  (Fixes #368)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -52,7 +52,7 @@
         {
             "source": "/core",
             "destination": "/research/",
-            "type": 302
+            "type": 301
         },
         {
             "source": "/concepts/wellbeing",
@@ -65,13 +65,13 @@
             "type": 302
         },
         {
-            "source": "/research/2022/dora-report",
-            "destination": "https://cloud.google.com/devops/state-of-devops",
+            "source": "/dora-report-:year",
+            "destination": "/research/:year/dora-report",
             "type": 302
         },
         {
-            "source": "/dora-report-:year",
-            "destination": "/research/:year/dora-report",
+            "source": "/dora-report",
+            "destination": "https://cloud.google.com/devops/state-of-devops",
             "type": 302
         }
       ]


### PR DESCRIPTION
Fixes #368

This PR:
- adds the 2022 report PDF (at URL `/research/2022/dora-report/2022-dora-accelerate-state-of-devops-report.pdf`)
- adds a convenience link: `dora.dev/dora-report`, which redirects to the page on cloud.google.com where users can download the latest report
- changes the redirect for `/core` to a 302 (just because I was in that file and there's no longer a reason for that to be a temporary redirect)