### PR TITLE
"DORA for Execs" guide  (Fixes #405)

### DIFF
--- a/hugo/archetypes/devops-capabilities.md
+++ b/hugo/archetypes/devops-capabilities.md
@@ -3,8 +3,14 @@ title: "{{ replace .Name "-" " " | title }}"
 titleForHTMLHead: "DevOps Capabilities: {{ replace .Name "-" " " | title }}" # TODO: can we DRY this out?
 date: {{ .Date }}
 category: 
+authors: 
 draft: true
-summary: "A summary (150-250 words) that describes this capability."
+slug: {{ .Name }}
+core: false
+headline: "A one sentence description, used on the `/devops-capabilities` section page"
+summary: |
+    [If core == false, delete this] A paragraph-length summary of the concepts in this article; used in the modal pop-ups linked from the Core diagram.
+
 ---
 
 This is where the article content goes. Replace this text with the article content. You can use images, too: place the image file in the same directory as this markdown file, and reference them with standard markdown formatting, e.g. `![my image](myImage.png)`

--- a/hugo/assets/scss/headings.scss
+++ b/hugo/assets/scss/headings.scss
@@ -52,6 +52,19 @@ hr {
     margin: 2em 0;
 }
 
+.authors {
+    margin-bottom:1rem;
+    a {
+        display:inline-block;
+        font-weight:200;
+        border:1px solid $border-light;
+        padding: 0 .4rem;
+        text-decoration: none;
+        border-radius:.4rem;
+        margin-right:.5em;
+    }
+}
+
 @include media-medium {
     $base-mobile-heading-size: 24px;
 

--- a/hugo/content/devops-capabilities/cultural/how-to-empower-software-delivery-teams/index.md
+++ b/hugo/content/devops-capabilities/cultural/how-to-empower-software-delivery-teams/index.md
@@ -1,0 +1,62 @@
+---
+title: "How to empower software delivery teams as a business leader"
+titleForHTMLHead: "How to empower software delivery teams as a business leader" # TODO: can we DRY this out?
+date: 2023-10-01T13:45:46-04:00
+category: cultural
+authors: 
+    1: {name: 'Steve Fenton', url: 'https://linkedin.com/in/stevefenton'}
+    2: {name: 'Mark Kropf', url: 'https://www.linkedin.com/in/markkropf/'}
+    3: {name: 'Denali Lumma', url: 'https://www.linkedin.com/in/denali-lumma/'}
+draft: true
+slug: how-to-empower-software-delivery-teams
+core: false
+headline: Measure and enable performance to help teams deliver value.
+
+---
+## A guide to facilitating the flow of value
+
+Measurement is vital for developing high-performance software delivery teams. Without metrics to inform the process, learning from experiments is limited. In the worst case, the attempt could result in a worse outcome. Let's explore the impact of measuring for performance versus measuring for productivity on your ability to meet your goals.
+
+### Productivity and performance
+Productivity is a measure of the efficiency of production for goods and services. In contexts where a clear line can be drawn from inputs to outputs, turning up the dial on inputs inevitably produces more outputs: put more materials in, get more toasters out. In software delivery, however, the search for the complex combination of inputs that can be dialed up to provide the desired outputs has been fruitless. We’re not delivering the same toaster in greater numbers—if ten lines of code make you $10, you'd be unwise to predict that a thousand lines of code will bring you $1,000. In fact, adding code can reduce revenue, by adding complexity.
+
+We think there are healthier ways to bring measurement to software delivery, by optimizing for performance, rather than productivity.
+
+### Measuring software delivery performance with DORA
+Research by DORA has found a strong link between software delivery performance and organizational outcomes. When teams perform well in software delivery, the organization is more likely to meet or exceed its goals. This is an exciting finding for folks responsible for making critical decisions. With a focus on performance, you can make high-quality decisions that help you achieve commercial and non-commercial goals.
+
+The DORA research program is grounded in performance at the level of the team—a cross-functional group who are collectively responsible for the ongoing development and delivery of a product or service. Since 2014, DORA has been refining a model that includes four key metrics of software delivery performance, and a catalog of essential capabilities shown to be predictive of performance, as captured in those key metrics. 
+
+Let’s look at how leaders at all levels of an organization can leverage these insights to understand and enhance their teams’ software delivery performance.
+
+### Software delivery managers
+Software delivery managers often get praised for burning down a backlog as fast as possible, and scolded when quality issues manifest downstream. Evaluation along these lines can impede deeper progress. To achieve a successful outcome over the long term, the manager needs to nurture sustainable team performance, of the kind that can only result from investing in the team itself.
+
+The DORA metrics (the four keys) are a great way to assess your software delivery performance. You can use the [quick check]({{< relref "/quickcheck" >}}) to discover the performance of each of your applications. You can collaborate with your team to find improvement opportunities, and the [DORA Core Model]({{< relref "/research" >}}) has a menu of capabilities you can draw on to help generate improvement ideas. Your team may think that a lack of deployment automation is causing infrequent deployments, so you could introduce this capability and measure its impact.
+
+> The best use of the DORA metrics is to track the same application over time.
+
+Software delivery performance is not an individual measure; it measures your ability to change and update an application, and this can only be done by teams. For example, an individual’s commit velocity could be constrained by slow code reviews, rather than a lack of skill. As a team manager, you should apply generous levels of curiosity to find the causes of performance differences within the system before you focus on the individual.
+
+### Directors
+When you move up a level in your organization's hierarchy, your focus naturally shifts, too. If the software delivery managers report to you, your job is to help these managers build successful teams. Directors are often asked about the health of applications or product lines, which trends in DORA metrics can reveal.
+
+The DORA Core Model reveals the impact of cultural capabilities on organizational outcomes, and directors are in the best position to drive those capabilities and to lead software delivery managers to create the conditions that drive performance. Directors can incentivize capability experimentation and create a shared vision around organizational goals.
+
+This kind of participation helps directors stay informed at a faster frequency than the annual review cycle and will make them more responsive when peers or the C-suite ask for changes.
+
+At the director level, it is important to avoid reductive aggregation across teams or comparison across different contexts. The performance of an application and team represents a complex set of interrelated factors, and it's more valuable to focus on comparisons for the same application and team, over time, to demonstrate improvement.
+
+### Executive Leadership
+With executive leadership, software should be measured against its purpose. To put this another way, there's a reason the organization invested in software, and this goal should be tracked. It should be possible to see the performance against the goal relative to cost (but not to assume that increased investment will amplify the performance).
+
+If the software was created to reduce response times, these response times should be measured. If it was created to sell as a software product, the profitability should be tracked.
+
+Continuous improvement is an ideal metric for a C-suite leader's OKR. During times of rapid market change, mergers and acquisitions, and shifting focus, the ability of an organization to deliver change remains an objective measure.
+
+The DORA Core Model shows that investment in specific capabilities is required to sustain continuous improvement. While the software delivery managers will assess the impact on software delivery performance, the c-suite should be able to see the impact on organizational performance—namely, the attainment of commercial and non-commercial goals.
+
+### How top performers win
+An organization with a healthy culture and teams of highly satisfied individuals will outperform competitors. Software delivery teams will find that detailed measurements help them generate high-quality improvement ideas. However, measurement brings risk: The same metrics that are vital to high performance and good outcomes can directly damage the cultural conditions necessary for success.
+
+We’ve observed that alignment and autonomy are a potent combination. The strong link between software delivery performance and organizational outcomes means teams can be empowered to reflect on their own practices and make improvements over time.

--- a/hugo/layouts/devops-capabilities/single.html
+++ b/hugo/layouts/devops-capabilities/single.html
@@ -8,6 +8,13 @@
     {{ .Title }}
     {{ if .Params.core }}<a class="core" href='{{ relref . "/research/" }}'>core</a>{{ end }}
 </h1>
+{{ if .Params.authors }}
+    <div class="authors">
+        {{ range .Params.authors }}
+            <a href="{{ .url }}" target="blank">{{ .name }}</a>
+        {{ end }}
+    </div>
+{{ end }}
 <section class="hasSidebar">
     <article>
         {{ .Content }}


### PR DESCRIPTION
This PR stages the "DORA for leadership" guide, under the Cultural DevOps Capabilities. (Similarly to "How to Transform," this is a slightly different kind of content than most of the capabilties. As a fast-follow, we plan to move such Guides into a new section. That will happen after State of DevOps 2023 is published.)

Note that because the front matter specifies `draft: true`, the article will only be visible on the draft server for now.



Fixes #405