### PR TITLE
Updates the research team for 2023

### DIFF
--- a/hugo/content/research/team.md
+++ b/hugo/content/research/team.md
@@ -13,10 +13,6 @@ stylesheets:
 ![Derek Debellis](/img/headshots/derek-debellis.jpeg)
 Derek DeBellis is a quantitative researcher at Google. At Google, Derek focuses on survey research, logs analysis, and figuring out ways to measure concepts central to product development. Derek has recently published on Human-AI interaction, the impact of COVID-19's onset on smoking cessation, designing for NLP errors, and the role of UX in privacy discussions.
 
-### Dustin Smith
-![Dustin Smith](/img/headshots/dustin-smith.jpeg)
-Dustin Smith is a human factors psychologist and staff research manager at Google, where he has worked on the DORA project since 2019. For over ten years, he has studied how people are affected by the systems and environments around them in a variety of contexts: software engineering, free-to-play gaming, healthcare, and military. His research at Google identifies areas where software developers can feel happier and more productive during development. Dustin received his PhD in Human Factors Psychology from Wichita State University.
-
 ### Kim Castillo
 ![Kim Castillo](/img/headshots/kim-castillo.jpeg)
 Kim Castillo is a UXR program manager at Google and drives the cross-functional effort behind the Accelerate State of DevOps Report. Kim likewise supports developer experience UX research in Google Cloud. The DORA program combines Kim's passion for research, software delivery practice, and coaching. Prior to Google, Kim worked as a delivery lead/technical program manager for several backend service teams, and as an agile development practices coach.
@@ -28,20 +24,26 @@ Michelle Irvine is a technical writer at Google. She has been part of the DORA p
 ## Meet the DORA Collective
 The collective includes current and former leaders, researchers, authors, and subject matter experts who have all made significant contributions to the research program.
 
+  - Amnanda Lewis
   - Brenna Washington
   - Claire Peters
-  - Daniella Villalba
+  - Daniella Villalba, PhD
   - Dave Farley
   - Dave Stanke
+  - Dustin Smith
   - Eric Maxwell
   - Frank Xu
   - Gene Kim
+  - James Brookbank
+  - Jeffrey P. Winer, PhD
   - Jessie Frazelle
   - Jez Humble
   - John Speed Mayers
+  - Kevin Storer
   - Lolly Chessie
   - Nathen Harvey
-  - Nicole Forsgren
+  - Nicole Forsgren, PhD
+  - Steve McGhee
   - Todd Kulesza
 
 Prior to 2018, The State of DevOps Report was published [in partnership with Puppet](https://www.puppet.com/resources/history-of-devops-reports).


### PR DESCRIPTION
* Dustin Smith moves to the collective
* Add to the collective:
  * Amanda Lewis
  * James Brookbank
  * Jeffrey P. Winer, PhD
  * Kevin Storer
  * Steve McGhee

Recognize PhDs for Daniella Villalba and Nicole Forsgren