### PR TITLE
add /report shortlink

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -86,6 +86,11 @@
         },
         {
             "source": "/dora-report",
+            "destination": "/report",
+            "type": 302
+        },
+        {
+            "source": "/report",
             "destination": "https://cloud.google.com/devops/state-of-devops",
             "type": 302
         },


### PR DESCRIPTION
This PR adds a shortlink: `/report` which redirects to the latest State of DevOps Report. Preview at https://staging.dora.dev/report

After this is merged and deployed, we can send users to `dora.dev/report` to download the newest report.