### PR TITLE
feat: change publication links for 2021 and 2022

### DIFF
--- a/hugo/content/publications/_index.md
+++ b/hugo/content/publications/_index.md
@@ -30,11 +30,11 @@ stylesheets:
 
 - [![2022 Accelerate State of DevOps Report](/research/2022/dora-report/2022-dora-accelerate-state-of-devops-report_landscape.png)](/research/2022/dora-report/2022-dora-accelerate-state-of-devops-report.pdf)
   #### [2022 Accelerate State of DevOps Report](/research/2022/dora-report/2022-dora-accelerate-state-of-devops-report.pdf)
-  [Read PDF](/research/2022/dora-report/2022-dora-accelerate-state-of-devops-report.pdf)
+  [Download the report](/research/2022/dora-report/)
 
 - [![2021 Accelerate State of DevOps Report](/research/2021/dora-report/2021-dora-accelerate-state-of-devops-report.png)](/research/2021/dora-report/2021-dora-accelerate-state-of-devops-report.pdf)
   #### [2021 Accelerate State of DevOps Report](/research/2021/dora-report/2021-dora-accelerate-state-of-devops-report.pdf)
-  [Read PDF](/research/2021/dora-report/2021-dora-accelerate-state-of-devops-report.pdf)
+  [Download the report](/research/2021/dora-report/)
 
 - [![2019 Accelerate State of DevOps Report](/research/2019/dora-report/2019-dora-accelerate-state-of-devops-report.png)](/research/2019/dora-report/2019-dora-accelerate-state-of-devops-report.pdf)
   #### [2019 Accelerate State of DevOps Report](/research/2019/dora-report/2019-dora-accelerate-state-of-devops-report.pdf)


### PR DESCRIPTION
There are multiple versions of the 2021 and 2022 reports.  When linking from the publication page send users to the appropriate report page where they can select their language of choice.  This is an extra click but is preferred over simply linking direcly to the English-language PDF.

The link text is also altered from "Read PDF" to "Download the report" to more clearly indicate what will happen next.