### PR TITLE
add ids to survey question headings

### DIFF
--- a/hugo/layouts/research_archives/questions/single.html
+++ b/hugo/layouts/research_archives/questions/single.html
@@ -14,7 +14,7 @@
         <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ .Params.research_year }}/dora-report/">{{ .Params.research_year }} Accelerate State of DevOps Report</a></h4>
         {{ range where .Site.Data.survey_questions "year" .Params.research_year }}
             {{ range sort .categories "heading" }}
-                <h3>{{ .heading }}</h3>
+                <h3 id="{{ .heading | anchorize }}">{{ .heading }}</h3>
                 {{ range sort .question_groups "description" }}
                     <p class="description">{{ .description }}</p>
                     <ul>


### PR DESCRIPTION
This PR adds `id` elements to headings on the Survey Question pages within `/research/<year>` sections.

By adding `id`s, anchor links will automatically be appended, by the script /hugo/themes/dora/layouts/partials/heading_anchor_links.html

Preview example:
https://doradotdev-staging--pr454-draft-b6a7pjiv.web.app/research/2023/questions/#burnout

Fixes #452 