### PR TITLE
fix "take precedence over other work" link

### DIFF
--- a/hugo/content/devops-capabilities/technical/continuous-integration/index.md
+++ b/hugo/content/devops-capabilities/technical/continuous-integration/index.md
@@ -93,7 +93,7 @@ software delivery performance:
     They merge their work into a shared trunk/mainline at least daily, rather
     than working on long-lived feature branches.
 -   An agreement that when the build breaks, fixing it should
-    [take priority over any other work](/devops-capabilities/technical/trunk-based-development).
+    [take priority over any other work](/devops-capabilities/technical/continuous-delivery/).
 
 CI requires
 [automated unit tests](/devops-capabilities/technical/test-automation).


### PR DESCRIPTION
The capability article on CI links the phrase "An agreement that when the build breaks, fixing it should take priority over any other work." to the TBD article. However, that concept is actually described in the CD article. This PR fixes that.