### PR TITLE
fix:  knowledge sharing questions

### DIFF
--- a/hugo/data/survey_questions/2023.json
+++ b/hugo/data/survey_questions/2023.json
@@ -240,7 +240,7 @@
                     "description": "Please rate your level of agreement with the following statements:",
                     "questions": [
                         "I often find myself answering questions that I've already answered before",
-                        "Please rate your level of agreement with the following statements:",
+                        "Knowledge silos prevent me from getting ideas across the organization",
                         "Waiting on answers to questions often causes interruptions and disrupts my workflow"
                     ]
                 }


### PR DESCRIPTION
adds the missing question about knowledge sharing:  Knowledge silos prevent me from getting ideas across the organization

Preview fix:  https://doradotdev-staging--pr466-2fgml8kl.web.app/research/2023/questions/#knowledge-sharing

fixes #465