### PR TITLE
fix: Kevin Storer's credentials

### DIFF
--- a/hugo/content/research/team.md
+++ b/hugo/content/research/team.md
@@ -37,7 +37,7 @@ The collective includes current and former leaders, researchers, authors, and su
   - Jessie Frazelle
   - Jez Humble
   - John Speed Mayers
-  - Kevin Storer
+  - Kevin Storer, PhD
   - Lolly Chessie
   - Nathen Harvey
   - Nicole Forsgren, PhD


### PR DESCRIPTION
Adds PhD to Kevin's listing on the research collective page

Preview here:  https://doradotdev-staging--pr468-zybrf6iy.web.app/research/team/#meet-the-dora-collective

fixes #467