### PR TITLE
Adds RSS capability using default Hugo template

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -1,6 +1,7 @@
 baseURL = 'https://dora.dev/'
 languageCode = 'en-us'
 theme = 'dora'
+rssLimit = 10
 
 [markup.goldmark.renderer]
 unsafe= true

--- a/hugo/themes/dora/layouts/partials/head.html
+++ b/hugo/themes/dora/layouts/partials/head.html
@@ -23,6 +23,9 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+{{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
 
 <!-- 2023-08-09: @davidstanke is disabling these and moving the webfont requests into `main.scss`. If nothing bad happens as a result, delete these: -->
 <!-- <link href="https://fonts.googleapis.com/css2?family=Google+Sans:400,500,700|Google+Sans+Text:300,400,500,700" rel="stylesheet"> -->


### PR DESCRIPTION
This sets up the RSS capability.

We can create a custom RSS template if needed. This uses Hugo's default.

The feed is added at `/index.xml` and there's a reference to this in the HTML head of the site, to help with discoverability.

See #433 