### PR TITLE
Remove links to rework.withgoogle.com

### DIFF
--- a/hugo/content/devops-capabilities/cultural/devops-culture-transform/index.md
+++ b/hugo/content/devops-capabilities/cultural/devops-culture-transform/index.md
@@ -36,7 +36,7 @@ organization.
 There are many frameworks for executing and measuring organizational change,
 such as
 [balanced scorecard](https://wikipedia.org/wiki/Balanced_scorecard),
-[objectives and key results (OKRs)](https://rework.withgoogle.com/guides/set-goals-with-okrs/steps/introduction/),
+[objectives and key results (OKRs)](https://en.wikipedia.org/wiki/Objectives_and_key_results),
 and the
 [improvement kata](http://www-personal.umich.edu/~mrother/The_Improvement_Kata.html)
 and
@@ -131,7 +131,7 @@ will be addressed.
 Some important points about this pattern are the following:
 
 -   A team's own target conditions or
-    [OKRs](https://rework.withgoogle.com/guides/set-goals-with-okrs/steps/introduction/)
+    [OKRs](https://en.wikipedia.org/wiki/Objectives_and_key_results)
     must be set by the team. If they are set in a top-down way, teams won't have
     a stake in the outcome and thus won't be as invested in achieving them.
     Instead, the team might "game" them—that is, manipulate the outcome to meet

--- a/hugo/content/devops-capabilities/cultural/generative-organizational-culture/index.md
+++ b/hugo/content/devops-capabilities/cultural/generative-organizational-culture/index.md
@@ -47,9 +47,9 @@ generative culture predicts software delivery and organizational performance in
 technology.
 
 Research from
-[a large two-year study at Google](https://rework.withgoogle.com/blog/five-keys-to-a-successful-google-team/)
+[a large two-year study at Google](https://www.nytimes.com/2016/02/28/magazine/what-google-learned-from-its-quest-to-build-the-perfect-team.html)
 found similar results: that high performing teams need a culture of trust and
-[psychological safety](https://rework.withgoogle.com/guides/understanding-team-effectiveness/steps/foster-psychological-safety/),
+[psychological safety](https://en.wikipedia.org/wiki/Psychological_safety),
 meaningful work, and clarity. In the
 [2019 State of DevOps Report](https://services.google.com/fh/files/misc/state-of-devops-2019.pdf)
 further analysis shows that a culture of psychological safety is predictive of
@@ -180,5 +180,3 @@ changes in order to preserve the statistical properties.
 -   Take the
     [DevOps quick check](/quickcheck/)
     to understand where you stand in comparison with the rest of the industry.
--   Check out Google's
-    [guide to understanding team effectiveness](https://rework.withgoogle.com/guides/understanding-team-effectiveness/steps/introduction/).

--- a/hugo/content/devops-capabilities/technical/continuous-delivery/index.md
+++ b/hugo/content/devops-capabilities/technical/continuous-delivery/index.md
@@ -87,7 +87,7 @@ the following benefits:
     are disruptive rather than easy and pain-free, as well as the fear and
     anxiety that engineers and technical staff feel when they push code into
     production.
--   Impacts culture, leading to greater levels of [psychological safety](https://rework.withgoogle.com/print/guides/5721312655835136/) and a
+-   Impacts culture, leading to greater levels of [psychological safety](https://en.wikipedia.org/wiki/Psychological_safety) and a
     more [mission-driven organizational culture](/devops-capabilities/cultural/generative-organizational-culture).
 
 The following diagram shows how a set of technical practices impacts


### PR DESCRIPTION
The site has been taken down so this updates links to new targets.