### PR TITLE
fix quickcheck 2019 alignment

### DIFF
--- a/hugo/assets/scss/quickcheck_2019.scss
+++ b/hugo/assets/scss/quickcheck_2019.scss
@@ -141,9 +141,11 @@ section.quickcheck_results {
             margin: 0.5rem;
             padding: 0.5rem 0.5rem 1rem 0.5rem;
 
-            h3 {
+            p {
                 color: $color-text;
-                font-weight: 500;
+                font-weight: 300;
+                font-family: $font-google-sans;
+                font-size: 1.5rem;
             }
 
             a {

--- a/hugo/content/quickcheck/2019/results.html
+++ b/hugo/content/quickcheck/2019/results.html
@@ -69,25 +69,28 @@ type: quickcheck_2019
         <div class="capabilities-container">
             <div class="rec">
                 <a  id="rec-link-0"
-                    href="/devops-capabilities/technical/version-control/">
+                    href="/devops-capabilities/technical/version-control/"
+                    target="_blank">
                     <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-0" alt="Icon that represents this capability">
-                    <h3 id="rec-name-0">Version control</h3>
+                    <p id="rec-name-0">Version control</p>
                     Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
                 </a>
             </div>
             <div class="rec">
                 <a  id="rec-link-1"
-                    href="/devops-capabilities/technical/version-control/">
+                    href="/devops-capabilities/technical/version-control/"
+                    target="_blank">
                     <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-1" alt="Icon that represents this capability">
-                    <h3 id="rec-name-1">Version control</h3>
+                    <p id="rec-name-1">Version control</p>
                     Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
                 </a>
             </div>
             <div class="rec">
                 <a  id="rec-link-2"
-                    href="/devops-capabilities/technical/version-control/">
+                    href="/devops-capabilities/technical/version-control/"
+                    target="_blank">
                     <img src="https://www.google.com/images/icons/material/system/svg/assignment_turned_in_24px.svg" class="rec-img" id="rec-img-2" alt="Icon that represents this capability">
-                    <h3 id="rec-name-2">Version control</h3>
+                    <p id="rec-name-2">Version control</p>
                     Learn more <img class="h-c-icon" alt="Arrow pointing right" src="https://www.gstatic.com/images/icons/material/system_gm/svg/arrow_right_alt_24px.svg">
                 </a>
             </div>


### PR DESCRIPTION
A side effect of #451 caused improper alignment on results from the 2019 quick check (see #474). This PR fixes the alignment by changing `<h3>` elements to `<p>` elements. It also adds `target="_blank"` so the links to capability articles will open in new tabs.

Preview:
https://doradotdev-staging--pr476-draft-gamkzldy.web.app//quickcheck/2019/results/?leadtime=5&deployfreq=4&chgfail=6&ttr=6&industry=government

Fixes #474