### PR TITLE
Fix mention of the Datastore service on the "Loosely coupled architecture" page

### DIFF
--- a/hugo/content/devops-capabilities/technical/loosely-coupled-architecture/index.md
+++ b/hugo/content/devops-capabilities/technical/loosely-coupled-architecture/index.md
@@ -309,7 +309,7 @@ a service like Gmail, there's five or six other layers of services underneath
 it, each very focused on a very specific function. Each service is
 supported by a small team, who builds it and runs their functionality, with
 each group potentially making different technology choices. Another example
-is the { service, which is one of the largest NoSQL
+is the Datastore service, which is one of the largest NoSQL
 services in the world, and yet it is supported by a team of only about
 eight people, largely because it is based on layers upon layers of
 dependable services built upon each other."


### PR DESCRIPTION
While reading the page that describes the [Loosely coupled architecture](https://dora.dev/devops-capabilities/technical/loosely-coupled-architecture/) capability, I noticed an out of place `{` under the "Case study: Datastore" section. 
I think that the author meant to mention "Datastore service" there, but I'm not entirely sure.