### PR TITLE
add heading link to capabilities index

### DIFF
--- a/hugo/layouts/devops-capabilities/section.html
+++ b/hugo/layouts/devops-capabilities/section.html
@@ -3,7 +3,7 @@
     {{- partial "partials/link_styles" "scss/devops-capabilities.scss" -}}
 
     {{ range (slice "technical" "process" "cultural") }}
-        <h2>{{ . | title }} capabilities</h2>
+        <h2 id="{{ . }}">{{ . | title }} capabilities</h2>
         <section class="capabilitiesGrid">
             {{ $capabilities := where site.RegularPages "Params.category" . }}
             {{ range ($capabilities.ByParam "title") }}


### PR DESCRIPTION
This PR adds `id` attributes to the `<h2>` tags on the Capabilities index, so that they will automatically reveal anchor URLs on hover.

https://doradotdev-staging--pr484-draft-e41wym63.web.app/devops-capabilities/#technical