### PR TITLE
The ROI report is no longer availalbe

### DIFF
--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -23,6 +23,19 @@ We've outlined the DevOps practices that drive successful software delivery and 
 Use these findings to accelerate organizational performance while reducing burnout.
 {{< /article >}}
 
+{{< article 
+    columns="2" 
+    title="Vote for DORA in the DevOps Dozen Awards" 
+    url="https://www.surveymonkey.com/r/DevOpsDozen2023"
+    cta="Cast your vote"
+    img-src="/resources/img/2023_devopsdozen_vote.png"
+    img-align="left" 
+    delete_on="2024-01-01" >}}
+DORA's Accelerate State of DevOps Report has been nominated for *Best DevOps Survey/Analysis/Research*, which recognizes "research that has significantly and positively impacted the DevOps community." And DORA Advocate Amanda Lewis has been nominated for *Top DevOps Evangelist* in recognition of her leadership in the DORA Community.
+
+Public voting is now open. [**Cast your vote**](https://www.surveymonkey.com/r/DevOpsDozen2023) to share how DORA's research and community have benefited you!
+{{< /article >}}
+
 {{< article columns="1" 
     title="DORA Quick Check" 
     url="/quickcheck/"
@@ -44,34 +57,10 @@ DORA Core represents the most well-established findings across the history and b
 {{< /article >}}
 
 {{< article 
-    columns="1" 
+    columns="2" 
     title="DevOps Awards" 
     cta="See the Winners"
     url="https://cloud.google.com/blog/topics/devops-awards" 
     >}}
 The Winners of the DevOps Awards are implementing DevOps practices to drive organizational success and deliver high-quality customer experiences. Read about their journeys and learn how they applied a philosophy of continuous improvement.
-{{< /article >}}
-
-{{< article 
-    columns="1" 
-    title="The ROI of DevOps" 
-    url="https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper"
-    cta="Read the Whitepaper"
-    img-src="/img/features/whitepaper-roi.png"
-    img-align="left"
-    img-stroke="true" >}}
-Organizations are constantly grappling to quantify the value of technology transformation. The whitepaper takes an analytical, data-driven approach to forecast the value and justify investment in DevOps transformations.
-{{< /article >}}
-
-{{< article 
-    columns="2" 
-    title="Vote for DORA in the DevOps Dozen Awards" 
-    url="https://www.surveymonkey.com/r/DevOpsDozen2023"
-    cta="Cast your vote"
-    img-src="/resources/img/2023_devopsdozen_vote.png"
-    img-align="left" 
-    delete_on="2024-01-01" >}}
-DORA's Accelerate State of DevOps Report has been nominated for *Best DevOps Survey/Analysis/Research*, which recognizes "research that has significantly and positively impacted the DevOps community." And DORA Advocate Amanda Lewis has been nominated for *Top DevOps Evangelist* in recognition of her leadership in the DORA Community.
-
-Public voting is now open. [**Cast your vote**](https://www.surveymonkey.com/r/DevOpsDozen2023) to share how DORA's research and community have benefited you!
 {{< /article >}}

--- a/hugo/content/concepts/organizational-performance.md
+++ b/hugo/content/concepts/organizational-performance.md
@@ -18,6 +18,5 @@ summary: |
     - Achieving organization or mission goals
     
     Several years of analysis shows that, compared to low performers, organizations with the highest level of software delivery performance are twice as likely to exceed their goals. Employee well-being also contributes to organizational performance.
-    
-    Read the whitepaper: [ROI of DevOps Transformation](https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper)
+
 ---

--- a/hugo/content/publications/_index.md
+++ b/hugo/content/publications/_index.md
@@ -61,12 +61,9 @@ bannerSubtitle: "Findings from DORA's research program are made available throug
   (in partnership with Puppet)
   [Read PDF](/research/2017-and-earlier/2014-state-of-devops-report.pdf)
 
-## Additional Publications
+## Additional Publication
 <!-- add publications as list items, using markdown syntax (list items are designated with a leading dash) -->
 
-- [![ROI of DevOps Whitepaper](img/whitepaper-roi.png)](https://bit.ly/roi-of-devops)
-  **[The ROI of DevOps Transformation](https://bit.ly/roi-of-devops)**
-  [Get the Whitepaper](https://bit.ly/roi-of-devops)
 - [![DevOps Awards Winners 2021](img/devops_awards_fullebook.png)](https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf)
   **[DevOps Awards Winners 2021](https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf)**
   [Read the ebook](https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf)

--- a/hugo/content/research/2020/_index.md
+++ b/hugo/content/research/2020/_index.md
@@ -8,6 +8,4 @@ type: research_archives
 layout: single
 ---
 
-In 2020, DORA didn't write an Accelerate State of DevOps Report. We did, however, produce a whitepaper which explores the return on investment (ROI) that can be realized through a DevOps transformation project. [Read The ROI of DevOps Whitepaper](https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper)
-
-{{< image src="/img/features/whitepaper-roi.png" url="https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper" width="16em" border="1px solid #ccc" >}}  
+In 2020, DORA didn't write an Accelerate State of DevOps Report.

--- a/hugo/layouts/partials/pagefooter_gofurther.html
+++ b/hugo/layouts/partials/pagefooter_gofurther.html
@@ -10,13 +10,4 @@
             <button class="secondary">Explore research</button>
         </a>
     </div>
-    <div>
-        <h4>Calculate return on investment</h4>
-        <p>Learn how to forecast the value of DevOps transformations with our ROI whitepaper.
-            <small>(registration required)</small>
-        </p>
-        <a href="https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper" target="_blank">
-            <button class="secondary">Download whitepaper</button>
-        </a>
-    </div>
 </section>


### PR DESCRIPTION
Temporarily remvove from the site while we decide how to proceed

This removes links to the ROI report which has been removed for cloud.google.com

This should be reverted when the report is available again