### PR TITLE
Update footer link to new DORA YouTube channel

### DIFF
--- a/hugo/themes/dora/layouts/partials/footer.html
+++ b/hugo/themes/dora/layouts/partials/footer.html
@@ -5,7 +5,7 @@
             <span class="linkGroup">
                 <a class="google-material-icons" href="https://twitter.com/devops_research" target="_blank" aria-label="Follow us on Twitter">post_twitter</a>
                 <a class="google-material-icons" href="https://www.linkedin.com/company/devops-research-and-assessment/" target="_blank" aria-label="Follow us on LinkedIn">post_linkedin</a>
-                <a class="google-material-icons" href="https://www.youtube.com/playlist?list=PLIivdWyY5sqIcFlX94XzycCzssTEkyQ1Q" target="_blank" aria-label="Watch DORA videos on YouTube">post_youtube</a>
+                <a class="google-material-icons" href="https://www.youtube.com/@dora-dev" target="_blank" aria-label="Watch DORA videos on YouTube">post_youtube</a>
             </span>
             <span class="linkGroup">
                 <a href="/faq/">FAQ</a>


### PR DESCRIPTION
This PR changes the destination of the YouTube icon in the footer from the old (now deprecated) playlist to the new DORA YouTube channel.