### PR TITLE
Add job satisfaction answer options

### DIFF
--- a/hugo/data/survey_questions/2023.json
+++ b/hugo/data/survey_questions/2023.json
@@ -228,7 +228,7 @@
             "question_groups": [
                 {
                     "questions": [
-                        "Taking everything into consideration, how do you feel about your job as a whole?"
+                        "Taking everything into consideration, how do you feel about your job as a whole?|Extremely satisfied,Satisfied,Slightly satisfied,Neither satisfied nor dissatisfied,Slightly dissatisfied,Dissatisfied,Extremely dissatisfied,I don't know or prefer not to answer"
                     ]
                 }
             ]


### PR DESCRIPTION
The 2023 survey asked about job satisfaction but the phrasing of the question did not lend itself to a scale from 'strongly disagree' to 'strongly agree,'

This adds the response options:

* Extremely satisfied
* Satisfied
* Slightly satisfied
* Neither satisfied nor dissatisfied
* Slightly dissatisfied
* Dissatisfied
* Extremely dissatisfied
* I don't know or prefer not to answer

Validate at https://doradotdev-staging--pr520-drafts-off-7mt6wy3a.web.app/research/2023/questions/#job-satisfaction

Compare to https://dora.dev/research/2023/questions/#job-satisfaction