### PR TITLE
remove 2023 report banner

### DIFF
--- a/hugo/layouts/partials/site_banner.html
+++ b/hugo/layouts/partials/site_banner.html
@@ -1,3 +1,3 @@
-<div class="site-banner">
+<!-- <div class="site-banner">
     The Accelerate State of DevOps Report 2023 is now available! <a href="https://cloud.google.com/devops/state-of-devops" target="_blank">Download the 2023 DORA Report</a>
-</div>
+</div> -->


### PR DESCRIPTION
It's time to turn off the banner promoting the 2023 state of devops report.