### PR TITLE
add redirect for transformation practices pdf

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -138,6 +138,11 @@
             "source": "/devops-capabilities/technical/shifting-left-on-security",
             "destination": "/devops-capabilities/process/shifting-left-on-security/",
             "type": 302
+          },
+          {
+            "source": "/assets/transformation_practices.pdf",
+            "destination":"https://itrevolution.com/wp-content/uploads/2022/06/transformation_practices.pdf",
+            "type":301
           }
       ]
     }


### PR DESCRIPTION
This PR adds a redirect for a PDF related to the Accelerate book, which is hosted on IT Revolution's site, but for which the bitly link in Accelerate points to this site (via redirect from devops-research.com).

Preview here (it should redirect to the PDF on itrevolution.com): https://staging.dora.dev/assets/transformation_practices.pdf


Fixes #537