### PR TITLE
Quick Check 2023: if a metric's value is an integer, omit the decimal component  (Fixes #541)

### DIFF
--- a/svelte/quick-check-2023/src/lib/YourPerformance.svelte
+++ b/svelte/quick-check-2023/src/lib/YourPerformance.svelte
@@ -145,8 +145,9 @@
         <span class="metric_description">{metrics.changefailure}% of changes fail</span>
     </aside>
     <div class="graph">
+        <!-- display change fail score with zero decimal places if it's a round number, else round to 1 decimal place -->
         <PerformanceGraph
-            user_score={metrics_recoded.changefailure.toFixed(1)}
+            user_score={+metrics_recoded.changefailure.toFixed(1)}
             industry_score={selected_industry_metrics.changefailure.mean}
             std={selected_industry_metrics.changefailure.std}
             tickmarks={[


### PR DESCRIPTION
Fixes #541

Preview at: 

https://doradotdev-staging--pr543-drafts-on-3rr3gw40.web.app/quickcheck/?leadtime=2&deployfreq=6&changefailure=50&failurerecovery=3&step=results&v=2023&industry=all
-vs-
https://doradotdev-staging--pr543-drafts-on-3rr3gw40.web.app/quickcheck/?leadtime=2&deployfreq=6&changefailure=51&failurerecovery=3&step=results&v=2023&industry=all
