### PR TITLE
Fix the failure recovery question text for the quick check

### DIFF
--- a/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
+++ b/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
@@ -25,7 +25,7 @@
         failurerecovery: {
             friendly_name: "Failed deployment recovery time",
             description:
-                "For the primary application or service you work on, what is your lead time for changes (that is, how long does it take to go from code committed to code successfully running in production)?",
+                "How long does it generally take to restore service after a change to production or release to users results in degraded service (for example, lead to service impairment or service outage) and subsequently require remediation (for example, require a hotfix, rollback, fix forward, or patch)?",
         },
     };
 


### PR DESCRIPTION
This resolves the issue with the question text for failed deployment recovery time.

![Failed deployment recovery time uses the lead time for changes question in the quick check](https://github.com/dora-team/dora.dev/assets/99181436/f0dd155c-d9b6-4326-b99e-246af2810159)

The question text has been obtained from the [2023 research questions](https://dora.dev/research/2023/questions/).