### PR TITLE
Redirect research archives

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -90,9 +90,29 @@
             "type": 302
         },
         {
-            "source": "/dora-report/[2017|2016|2015|2014]",
-            "destination": "/research/2017-and-earlier/:year-state-of-devops-report.pdf",
+            "source": "/dora-report-2014",
+            "destination": "/research/2017-and-earlier/2014-state-of-devops-report.pdf",
             "type": 302
+        },
+        {
+          "source": "/dora-report-2015",
+          "destination": "/research/2017-and-earlier/2015-state-of-devops-report.pdf",
+          "type": 302
+        },
+        {
+          "source": "/dora-report-2016",
+          "destination": "/research/2017-and-earlier/2016-state-of-devops-report.pdf",
+          "type": 302
+        },
+        {
+          "source": "/dora-report-2017",
+          "destination": "/research/2017-and-earlier/2017-state-of-devops-report.pdf",
+          "type": 302
+        },
+        {
+          "source": "/dora-report-2020",
+          "destination": "/research/2020/",
+          "type": 302
         },
         {
             "source": "/dora-report-:year",

--- a/firebase.json
+++ b/firebase.json
@@ -90,6 +90,11 @@
             "type": 302
         },
         {
+            "source": "/dora-report/[2017|2016|2015|2014]",
+            "destination": "/research/2017-and-earlier/:year-state-of-devops-report.pdf",
+            "type": 302
+        },
+        {
             "source": "/dora-report-:year",
             "destination": "/research/:year/dora-report",
             "type": 302

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -30,12 +30,11 @@
 /dora-report-2023,/research/2023/dora-report,302
 /dora-report-2022,/research/2022/dora-report,302
 /dora-report-2021,/research/2021/dora-report,302
-/dora-report-2020,/research/2020/dora-report,302
+/dora-report-2020,/research/2020/,302
 /dora-report-2019,/research/2019/dora-report,302
 /dora-report-2018,/research/2018/dora-report,302
 /dora-report-2017,/research/2017-and-earlier/2017-state-of-devops-report.pdf,302
 /dora-report-2016,/research/2017-and-earlier/2016-state-of-devops-report.pdf,302
 /dora-report-2015,/research/2017-and-earlier/2015-state-of-devops-report.pdf,302
 /dora-report-2014,/research/2017-and-earlier/2014-state-of-devops-report.pdf,302
-/dora-report-2020,/research/2020/,302
 /next24,/survey,302

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -35,5 +35,5 @@
 /dora-report-2018,/research/2018/dora-report,302
 /dora-report-2017,/research/2017-and-earlier/2017-state-of-devops-report.pdf,302
 /dora-report-2016,/research/2017-and-earlier/2016-state-of-devops-report.pdf,302
-/dora-report-2015,/2017-and-earlier/2015-state-of-devops-report.pdf,302
-/dora-report-2014,/2017-and-earlier/2014-state-of-devops-report.pdf,302
+/dora-report-2015,/research/2017-and-earlier/2015-state-of-devops-report.pdf,302
+/dora-report-2014,/research/2017-and-earlier/2014-state-of-devops-report.pdf,302

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -33,3 +33,7 @@
 /dora-report-2020,/research/2020/dora-report,302
 /dora-report-2019,/research/2019/dora-report,302
 /dora-report-2018,/research/2018/dora-report,302
+/dora-report-2017,/research/2017-and-earlier/2017-state-of-devops-report.pdf,302
+/dora-report-2016,/research/2017-and-earlier/2016-state-of-devops-report.pdf,302
+/dora-report-2015,/2017-and-earlier/2015-state-of-devops-report.pdf,302
+/dora-report-2014,/2017-and-earlier/2014-state-of-devops-report.pdf,302

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -37,4 +37,5 @@
 /dora-report-2016,/research/2017-and-earlier/2016-state-of-devops-report.pdf,302
 /dora-report-2015,/research/2017-and-earlier/2015-state-of-devops-report.pdf,302
 /dora-report-2014,/research/2017-and-earlier/2014-state-of-devops-report.pdf,302
+/dora-report-2020,/research/2020/,302
 /next24,/survey,302


### PR DESCRIPTION
Preview links:

* http://staging.dora.dev/dora-report-2023
* http://staging.dora.dev/dora-report-2022
* http://staging.dora.dev/dora-report-2021
* http://staging.dora.dev/dora-report-2020
* http://staging.dora.dev/dora-report-2019
* http://staging.dora.dev/dora-report-2018
* http://staging.dora.dev/dora-report-2017
* http://staging.dora.dev/dora-report-2016
* http://staging.dora.dev/dora-report-2015
* http://staging.dora.dev/dora-report-2014
