### PR TITLE
add /next24 redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -143,6 +143,11 @@
             "source": "/assets/transformation_practices.pdf",
             "destination":"https://itrevolution.com/wp-content/uploads/2022/06/transformation_practices.pdf",
             "type":301
+          },
+          {
+            "source": "/next24",
+            "destination": "/survey",
+            "type": 302
           }
       ]
     }

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -33,3 +33,4 @@
 /dora-report-2020,/research/2020/dora-report,302
 /dora-report-2019,/research/2019/dora-report,302
 /dora-report-2018,/research/2018/dora-report,302
+/next24,/survey,302


### PR DESCRIPTION
This PR adds a redirect for the URL `/next24` -- we will provide this to attendees at the Google Cloud Next conference so they can take the State of DevOps Survey (which we expect will be live by that time). Until the destination link is live, however, it simply redirects to the `/survey` page

preview at: https://staging.dora.dev/next24