### PR TITLE
More quick check styles / elements

### DIFF
--- a/hugo/content/quickcheck/kiosk/_index.md
+++ b/hugo/content/quickcheck/kiosk/_index.md
@@ -4,7 +4,7 @@ date: 2024-03-09
 draft: true
 ---
 
-<!-- resize `main`; hide the footer nav -->
+<!-- resize `main`; hide the header/footer nav -->
 <style>
     main {
         max-width: 100% !important;
@@ -12,6 +12,7 @@ draft: true
         padding: 0 !important;
     }
     footer {display:none}
+    header {display:none}
 </style>
 
 <meta name="displayMode" content="kiosk" />

--- a/hugo/content/quickcheck/kiosk/_index.md
+++ b/hugo/content/quickcheck/kiosk/_index.md
@@ -1,14 +1,14 @@
 ---
 title: "DORA Quick Check"
 date: 2024-03-09
-draft: true
+draft: false
 ---
 
 <!-- resize `main`; hide the header/footer nav -->
 <style>
     main {
         max-width: 100% !important;
-        margin: 1rem 1.5rem .5rem 1rem !important;
+        margin: 0 !important;
         padding: 0 !important;
     }
     footer {display:none}

--- a/svelte/quick-check-2023/index.html
+++ b/svelte/quick-check-2023/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://dora.dev/scss/main.ff4aaa5da040b42f03d6a70c3fb777c4bf9ccabee24ff7dcba661fdc24c39f81.css" />
   </head>
   <body>
+    <meta name="displayMode" content="kiosk" />
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/svelte/quick-check-2023/src/App.svelte
+++ b/svelte/quick-check-2023/src/App.svelte
@@ -7,7 +7,7 @@
     import HelpMePrioritize from "./lib/HelpMePrioritize.svelte";
     import GoFurther from "./lib/GoFurther.svelte";
     import { sendAnalyticsEvent } from "./lib/utils.js";
-    import FullScreen from "./lib/FullScreen.svelte";
+    import FullScreenButton from "./lib/FullScreenButton.svelte";
 
     let metrics = {
         leadtime: -1,
@@ -101,24 +101,31 @@
 
 <!--- END debug -->
 
+{#if displayMode === "kiosk"}
+    <FullScreenButton />
+{/if}
+
 <div class="quickcheck" class:displayMode>
     {#if displayMode === "kiosk"}
-        <FullScreen />
         <div class="kioskMetricsQuestions">
             <aside>
                 Take the
                 <h1>DORA Quick Check</h1>
             </aside>
             {#if step === "input"}
-                <MetricsQuestion
-                    bind:metrics
-                    bind:current_metric
-                    metric_name={metric_names[current_metric]}
-                    metric_position={current_metric}
-                    {displayMode}
-                />
+                {#key current_metric}
+                    <MetricsQuestion
+                        bind:metrics
+                        bind:current_metric
+                        metric_name={metric_names[current_metric]}
+                        metric_position={current_metric}
+                        {displayMode}
+                    />
+                {/key}
             {:else if step === "results"}
-                RESULTS (TODO)
+                <div>
+                    <YourPerformance {metrics} bind:industry />
+                </div>
             {/if}
         </div>
     {:else}
@@ -153,7 +160,7 @@
             <GoFurther />
         {/if}
     {/if}
-    </div>
+</div>
 
 <style lang="scss">
     :global(:root) {

--- a/svelte/quick-check-2023/src/App.svelte
+++ b/svelte/quick-check-2023/src/App.svelte
@@ -22,7 +22,7 @@
     let current_capability = -1;
     let metric_names = Object.keys(metrics);
     let current_metric = 0; // in kiosk mode, metrics questions are presented one at a time
-    let displayMode = "kiosk";
+    let displayMode = "embedded";
 
     function saveURLParams() {
         if (typeof window !== "undefined") {

--- a/svelte/quick-check-2023/src/App.svelte
+++ b/svelte/quick-check-2023/src/App.svelte
@@ -6,7 +6,9 @@
     import YourPerformance from "./lib/YourPerformance.svelte";
     import HelpMePrioritize from "./lib/HelpMePrioritize.svelte";
     import GoFurther from "./lib/GoFurther.svelte";
+    import Fullscreen from "./lib/Fullscreen.svelte";
     import { sendAnalyticsEvent } from "./lib/utils.js";
+    import FullScreen from "./lib/Fullscreen.svelte";
 
     let metrics = {
         leadtime: -1,
@@ -20,7 +22,7 @@
     let current_capability = -1;
     let metric_names = Object.keys(metrics);
     let current_metric = 0; // in kiosk mode, metrics questions are presented one at a time
-    let displayMode = "embedded";
+    let displayMode = "kiosk";
 
     function saveURLParams() {
         if (typeof window !== "undefined") {
@@ -41,6 +43,10 @@
         ) {
             displayMode = document.getElementsByName("displayMode")[0].content;
             console.log(`displayMode: ${displayMode} provided via <meta> tag`);
+        }
+
+        if (displayMode === "kiosk" && document.documentElement.requestFullscreen) {
+            document.documentElement.requestFullscreen()
         }
 
         const searchParams = new URLSearchParams(window.location.search);
@@ -102,6 +108,7 @@
 
 <div class="quickcheck" class:displayMode>
     {#if displayMode === "kiosk"}
+        <FullScreen />
         <div class="kioskMetricsQuestions">
             <aside>
                 Take the
@@ -174,6 +181,7 @@
     :global(body div.quickcheck) {
         padding-left: 0;
         padding-right: 0;
+        position: relative;
     }
 
     .faq {

--- a/svelte/quick-check-2023/src/App.svelte
+++ b/svelte/quick-check-2023/src/App.svelte
@@ -6,9 +6,8 @@
     import YourPerformance from "./lib/YourPerformance.svelte";
     import HelpMePrioritize from "./lib/HelpMePrioritize.svelte";
     import GoFurther from "./lib/GoFurther.svelte";
-    import Fullscreen from "./lib/Fullscreen.svelte";
     import { sendAnalyticsEvent } from "./lib/utils.js";
-    import FullScreen from "./lib/Fullscreen.svelte";
+    import FullScreen from "./lib/FullScreen.svelte";
 
     let metrics = {
         leadtime: -1,
@@ -43,10 +42,6 @@
         ) {
             displayMode = document.getElementsByName("displayMode")[0].content;
             console.log(`displayMode: ${displayMode} provided via <meta> tag`);
-        }
-
-        if (displayMode === "kiosk" && document.documentElement.requestFullscreen) {
-            document.documentElement.requestFullscreen()
         }
 
         const searchParams = new URLSearchParams(window.location.search);

--- a/svelte/quick-check-2023/src/lib/FullScreen.svelte
+++ b/svelte/quick-check-2023/src/lib/FullScreen.svelte
@@ -12,7 +12,7 @@
             fullscreen = true;
         } else if (document.exitFullscreen) {
             document.exitFullscreen();
-            fullscreen=false;
+            fullscreen = false;
         }
     }
 </script>
@@ -24,8 +24,6 @@
         toggleFullScreen();
     }}>{fullscreen_modes[!fullscreen]}</span
 >
-
-{fullscreen_modes[fullscreen]}
 
 <style>
     #fullscreen_container {

--- a/svelte/quick-check-2023/src/lib/FullScreen.svelte
+++ b/svelte/quick-check-2023/src/lib/FullScreen.svelte
@@ -1,0 +1,43 @@
+<script>
+    let fullscreen = false;
+
+    let fullscreen_modes = {
+        false: "fullscreen_exit",
+        true: "fullscreen",
+    };
+
+    function toggleFullScreen() {
+        if (!fullscreen && !document.fullscreenElement) {
+            document.documentElement.requestFullscreen();
+            fullscreen = true;
+        } else if (document.exitFullscreen) {
+            document.exitFullscreen();
+            fullscreen=false;
+        }
+    }
+</script>
+
+<span
+    class="google-material-icons"
+    id="fullscreen_container"
+    on:click={() => {
+        toggleFullScreen();
+    }}>{fullscreen_modes[!fullscreen]}</span
+>
+
+{fullscreen_modes[fullscreen]}
+
+<style>
+    #fullscreen_container {
+        display: block;
+        padding: 1rem;
+        position: absolute;
+        top: 0;
+        right: 1rem;
+    }
+
+    .google-material-icons {
+        color: #999;
+        cursor: pointer;
+    }
+</style>

--- a/svelte/quick-check-2023/src/lib/FullScreenButton.svelte
+++ b/svelte/quick-check-2023/src/lib/FullScreenButton.svelte
@@ -17,6 +17,7 @@
     }
 </script>
 
+{#if document.fullscreenEnabled}
 <span
     class="google-material-icons"
     id="fullscreen_container"
@@ -24,14 +25,16 @@
         toggleFullScreen();
     }}>{fullscreen_modes[!fullscreen]}</span
 >
+{/if}
 
 <style>
     #fullscreen_container {
         display: block;
         padding: 1rem;
-        position: absolute;
-        top: 0;
-        right: 1rem;
+        position: fixed;
+        top: .5rem;
+        right: .5rem;
+        z-index: 1000;
     }
 
     .google-material-icons {

--- a/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
+++ b/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
@@ -206,7 +206,7 @@
                 padding:.5rem 1rem;
                 user-select: none;
 
-                &:focus {
+                &:active {
                     background-color: var(--dora-blue);
                     color:white;
                 }

--- a/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
+++ b/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
@@ -1,4 +1,5 @@
 <script>
+    import { fade } from "svelte/transition";
     export let metrics;
     export let metric_name = "METRIC",
         metric_position = 1,
@@ -33,7 +34,10 @@
 </script>
 
 <!-- TODO: images on this page are inlined from "metrics_image.json" ... we should be able to use Vite to inline them automatically from static image files, which will make the source cleaner -->
-<div>
+<div
+    in:fade={{ delay: 350, duration: 100 }}
+    out:fade={{ delay: 250, duration: 100 }}
+>
     <section class="question {displayMode}">
         <aside>
             <h5>
@@ -50,48 +54,64 @@
                     {metrics_details[metric_name].description}
                 </p>
             </legend>
-            {#if metric_name === "changefailure"}
-                <slider>
-                    <input
-                        type="range"
-                        name="changefailure"
-                        min="0"
-                        max="100"
-                        on:change={() => current_metric++}
-                        bind:value={metrics["changefailure"]}
-                    />
-                    <echo>
-                        {#if metrics["changefailure"] >= 0}{metrics[
-                                "changefailure"
-                            ]}{/if}
-                    </echo>
-                    <tickmarks>
-                        <tick>|<br />0</tick>
-                        <tick>|</tick>
-                        <tick>|<br />20</tick>
-                        <tick>|</tick>
-                        <tick>|<br />40</tick>
-                        <tick>|</tick>
-                        <tick>|<br />60</tick>
-                        <tick>|</tick>
-                        <tick>|<br />80</tick>
-                        <tick>|</tick>
-                        <tick>|<br />100</tick>
-                    </tickmarks>
-                </slider>
-            {:else}
-                {#each Object.entries(metrics_question_responses[metric_name]) as [value, text]}
-                    <label
-                        ><input
-                            name={metric_name}
-                            type="radio"
-                            bind:group={metrics[metric_name]}
-                            on:click={() => current_metric++}
-                            {value}
-                        />{text}</label
-                    >
-                {/each}
-            {/if}
+            <div class="inputs">
+                {#if metric_name === "changefailure"}
+                    {#if displayMode === "embedded"}
+                        <slider>
+                            <input
+                                type="range"
+                                name="changefailure"
+                                min="0"
+                                max="100"
+                                on:change={() => current_metric++}
+                                bind:value={metrics["changefailure"]}
+                            />
+                            <echo>
+                                {#if metrics["changefailure"] >= 0}{metrics[
+                                        "changefailure"
+                                    ]}{/if}
+                            </echo>
+                            <tickmarks>
+                                <tick>|<br />0</tick>
+                                <tick>|</tick>
+                                <tick>|<br />20</tick>
+                                <tick>|</tick>
+                                <tick>|<br />40</tick>
+                                <tick>|</tick>
+                                <tick>|<br />60</tick>
+                                <tick>|</tick>
+                                <tick>|<br />80</tick>
+                                <tick>|</tick>
+                                <tick>|<br />100</tick>
+                            </tickmarks>
+                        </slider>
+                    {:else}
+                        {#each { length: 11 } as _, value}
+                            <label
+                                ><input
+                                    name="changefailure"
+                                    type="radio"
+                                    bind:group={metrics["changefailure"]}
+                                    on:click={() => current_metric++}
+                                    value={value * 10}
+                                />{value * 10}%</label
+                            >
+                        {/each}
+                    {/if}
+                {:else}
+                    {#each Object.entries(metrics_question_responses[metric_name]) as [value, text]}
+                        <label
+                            ><input
+                                name={metric_name}
+                                type="radio"
+                                bind:group={metrics[metric_name]}
+                                on:click={() => current_metric++}
+                                {value}
+                            />{text}</label
+                        >
+                    {/each}
+                {/if}
+            </div>
         </fieldset>
     </section>
 </div>
@@ -172,14 +192,21 @@
         &.kiosk {
             flex-direction: column;
             border-bottom: none;
+            position: absolute;
+            top: 0;
+            left: 40vw;
+
+            aside {
+                width: 35vw;
+            }
 
             p.description {
                 padding-top: 0;
-                font-size:1.5rem;
+                font-size: 1.5rem;
             }
 
             fieldset {
-                width:90%;
+                width: calc(100% - 1rem);
             }
 
             h2 {
@@ -194,22 +221,39 @@
             }
 
             // show radio options as buttons
-            input[type=radio] {
-                display:none;
+            input[type="radio"] {
+                display: none;
             }
 
             label {
-                font-size:1.65rem;
-                background-color:#eef;
-                border-radius:.5rem;
-                border:1px solid #e9e9f0;
-                padding:.5rem 1rem;
+                font-size: 1.65rem;
+                background-color: #eef;
+                border-radius: 0.5rem;
+                border: 1px solid #e9e9f0;
+                padding: 0.5rem 1rem;
                 user-select: none;
 
-                &:active {
+                &:active,
+                &:has(:checked) {
                     background-color: var(--dora-blue);
-                    color:white;
+                    color: white;
                 }
+
+                &:has(input[type="radio"][name="changefailure"]) {
+                    display: inline-block;
+                    font-size: 2rem;
+                    border-radius: 50%;
+                    width: 6rem;
+                    height: 6rem;
+                    text-align: center;
+                    line-height: 6rem;
+                    padding: 0;
+                    margin: 0.5rem;
+                }
+            }
+
+            div.inputs:has(input[type="radio"][name="changefailure"]) {
+                text-align: center;
             }
         }
     }

--- a/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
+++ b/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
@@ -204,6 +204,12 @@
                 border-radius:.5rem;
                 border:1px solid #e9e9f0;
                 padding:.5rem 1rem;
+                user-select: none;
+
+                &:focus {
+                    background-color: var(--dora-blue);
+                    color:white;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds styles (and some other bits) to enable kiosk mode for the quick check. It also takes the path `/quickcheck/kiosk` out of draft mode, so that will be live (though unlinked) on prod when this is merged. It's not quite done yet, but it's pretty close now.

Preview at:
https://doradotdev-staging--pr559-drafts-off-1nxaf54j.web.app/quickcheck/kiosk/

Default ("embedded") mode should be unchanged:
https://doradotdev-staging--pr559-drafts-off-1nxaf54j.web.app/quickcheck/

Note that the kiosk layout is specifically targeting a Pixel tablet and it may not be great at other sizes (it's not fully responsive).