### PR TITLE
Use relative links in the guide

### DIFF
--- a/hugo/content/guides/dora-metrics-four-keys/index.md
+++ b/hugo/content/guides/dora-metrics-four-keys/index.md
@@ -8,7 +8,7 @@ headline: "DORA’s software delivery metrics: the four keys"
 ---
 ## Effective measures
 
-Technology-driven teams need ways to measure performance so that they can assess how they're doing today, prioritize improvements, and validate their progress. DORA has identified four software delivery metrics—the _four keys_—that provide an effective way of measuring the outcomes of the software delivery process. DORA's [research](dora.dev/research) shows that these performance metrics predict better organizational performance and well-being for team members.
+Technology-driven teams need ways to measure performance so that they can assess how they're doing today, prioritize improvements, and validate their progress. DORA has identified four software delivery metrics—the _four keys_—that provide an effective way of measuring the outcomes of the software delivery process. DORA's [research](/research) shows that these performance metrics predict better organizational performance and well-being for team members.
 
 The four keys  can be viewed as both _leading_ and _lagging_ indicators. Leading indicators typically signal potential future changes in a system while lagging indicators reflect past performance and outcomes. 
 
@@ -56,31 +56,31 @@ There are some pitfalls to watch out for as your team adopts DORA’s software d
 * **Using industry as a shield against improving.** For example, some teams in highly regulated industries might claim that compliance requirements prevent them from disrupting the status quo.
 * **Making disparate comparisons.** These metrics are meant to be applied at the application or service level. Comparing metrics between vastly different applications (for example, a mobile app and a mainframe system) can be misleading.
 * **Having siloed ownership.** Sharing all four metrics across development, operations, and release teams fosters collaboration and shared ownership of the delivery process. Isolating teams with specific metrics can lead to friction and finger-pointing.
-* **Competing.** The goal is to [improve your team's performance](https://dora.dev/devops-capabilities/cultural/how-to-empower-software-delivery-teams/) over time, not to compete against other teams or organizations. Use the metrics as a guide for identifying areas for growth and celebrating progress.
-* **Focusing on measurement at the expense of improvement.** The data your team needs to collect for the four keys is available in a number of different places today. Building integrations to multiple systems to get precise data about your software delivery performance might not be worth the initial investment. Instead, it might be better to start with having conversations, taking the [DORA Quick Check](https://dora.dev/quickcheck), or using a software solution that comes with pre-built integrations.
+* **Competing.** The goal is to [improve your team's performance](/devops-capabilities/cultural/how-to-empower-software-delivery-teams/) over time, not to compete against other teams or organizations. Use the metrics as a guide for identifying areas for growth and celebrating progress.
+* **Focusing on measurement at the expense of improvement.** The data your team needs to collect for the four keys is available in a number of different places today. Building integrations to multiple systems to get precise data about your software delivery performance might not be worth the initial investment. Instead, it might be better to start with having conversations, taking the [DORA Quick Check](/quickcheck), or using a software solution that comes with pre-built integrations.
 
 What pitfalls have you encountered? Share your own cautionary tales with the DORA community by posting to the mailing list at [https://dora.community](https://dora.community).
 
 
 ## Dive into the research
 
-[DORA's research](https://dora.dev/research) goes beyond the four keys, exploring various capabilities that contribute to high performance. You can learn more about these capabilities and their impact on software delivery by visiting the [Capability catalog](https://dora.dev/devops-capabilities/).
+[DORA's research](/research) goes beyond the four keys, exploring various capabilities that contribute to high performance. You can learn more about these capabilities and their impact on software delivery by visiting the [Capability catalog](/devops-capabilities/).
 
 By understanding and effectively utilizing DORA metrics, you can gain valuable insights into your software delivery performance and drive continuous improvement. Remember, the goal is to deliver better software faster, and DORA metrics provide the compass to orient teams toward that objective.
 
 
 ## Next steps
 
-A common approach to improving the four key metrics discussed in this guide is [reducing the batch size of changes](https://dora.dev/devops-capabilities/process/working-in-small-batches/) for an application. Smaller changes are easier to rationalize and to move through the delivery process. Smaller changes are also easier to recover from if there's a failure. Teams should make each change as small as possible to make the delivery process fast and stable. Working in this way contributes to both change throughput and change stability.
+A common approach to improving the four key metrics discussed in this guide is [reducing the batch size of changes](/devops-capabilities/process/working-in-small-batches/) for an application. Smaller changes are easier to rationalize and to move through the delivery process. Smaller changes are also easier to recover from if there's a failure. Teams should make each change as small as possible to make the delivery process fast and stable. Working in this way contributes to both change throughput and change stability.
 
 We have found that an effective way of making changes is to gather the cross-functional team that is responsible for prioritizing, building, delivering, and operating an application for a discussion about improving their software delivery performance. Once the team is gathered, walk through the following steps:
 
-* **Set a baseline** for your application's current performance using the [DORA Quick Check](https://dora.dev/quickcheck)
-* **Have a conversation** about the friction points in the delivery process. [Mapping out the delivery process](https://dora.dev/devops-capabilities/process/work-visibility-in-value-stream/) may help facilitate this part of the process.
+* **Set a baseline** for your application's current performance using the [DORA Quick Check](/quickcheck)
+* **Have a conversation** about the friction points in the delivery process. [Mapping out the delivery process](/devops-capabilities/process/work-visibility-in-value-stream/) may help facilitate this part of the process.
 * **Have the whole team  commit to making an improvement** in the most significant constraint or bottleneck.
 * **Turn that commitment into a plan**, which may include some more specific measures that can serve as leading indicators for the software delivery metrics. For example, you may decide to measure how long code reviews take or the quality of your tests.
 * **Do the work**. There are very few shortcuts, to make progress your team may need to change the way they work.
-* **Check your progress**. Use the [DORA Quick Check](https://dora.dev/quickcheck), conversations, and team retrospectives to validate the progress you've made.
+* **Check your progress**. Use the [DORA Quick Check](/quickcheck), conversations, and team retrospectives to validate the progress you've made.
 * **Repeat** the process as a way to continue the learning and improvement. 
 
 Join us in the [DORA Community](https://dora.community) for ongoing discussions about how to implement DORA metrics in your organization!


### PR DESCRIPTION
This also fixes a broken link to /research

Preview and validate:  https://doradotdev-staging--pr566-drafts-off-lgk5b64h.web.app/guides/dora-metrics-four-keys/