### PR TITLE
Add countdown auto-restart function to Quick Check kiosk mode

### DIFF
--- a/svelte/quick-check-2023/src/App.svelte
+++ b/svelte/quick-check-2023/src/App.svelte
@@ -142,7 +142,11 @@
                     Take the
                     <h1>DORA Quick Check</h1>
                     {#if current_metric > 0}
-                        <StartOver on:reset={reset} {displayMode} />
+                        {#key step} <!-- re initialize this widget on every change of step or current_metric -->
+                            {#key current_metric}
+                                <StartOver on:reset={reset} {displayMode} />
+                            {/key}
+                        {/key}
                     {/if}
                 </aside>
                 {#key current_metric}

--- a/svelte/quick-check-2023/src/lib/kiosk/StartOver.svelte
+++ b/svelte/quick-check-2023/src/lib/kiosk/StartOver.svelte
@@ -1,15 +1,49 @@
 <script>
     import { createEventDispatcher } from "svelte";
+    import { onMount } from "svelte";
+    import { onDestroy } from "svelte";
 
-    export let displayMode="kiosk";
+    export let displayMode = "kiosk";
+
+    const TIMER_DURATION_IN_SEC = 90;
+    const TIMER_HIDDEN_FOR_SEC = 60;
+
+    let seconds_remaining = TIMER_DURATION_IN_SEC;
 
     const dispatch = createEventDispatcher();
 
-    const reset = () => dispatch("reset");
+    let countDownTimer;
+
+    const reset = () => {
+        seconds_remaining = TIMER_DURATION_IN_SEC;
+        dispatch("reset");
+    };
+
+    function countDown() {
+        if (seconds_remaining === 1) {
+            reset();
+        } else {
+            seconds_remaining--;
+            countDownTimer = setTimeout(countDown, 1000);
+        }
+    }
+
+    onMount(() => {
+        console.log("hi");
+        countDown();
+    });
+    onDestroy(() => {
+        clearTimeout(countDownTimer);
+    })
 </script>
 
 <div class="container {displayMode}">
     <a href="." on:click|preventDefault={reset} class="reset">start over</a>
+    <div class="auto-reset"> 
+        {#if seconds_remaining <= TIMER_DURATION_IN_SEC - TIMER_HIDDEN_FOR_SEC}
+            starting over in {seconds_remaining}s
+        {/if}
+    </div>
 </div>
 
 <style>
@@ -25,6 +59,11 @@
         margin: 0 3rem;
         color: #999;
         text-decoration: none;
+    }
+
+    div.auto-reset {
+        font-size: 1rem;
+        color: #999;
     }
 
     div.container.kiosk a.reset {


### PR DESCRIPTION
This PR adds a timer to the `StartOver` component which automatically resets the application if it is idle for 90 seconds. For the last 30 seconds, a decrementing counter is displayed on screen.

It only appears in Kiosk mode. There should be no visible impact to the default ("embedded") mode.

https://doradotdev-staging--pr570-drafts-on-qckob4ep.web.app/quickcheck/kiosk/