### PR TITLE
add redirect for next24

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -171,7 +171,7 @@
           },
           {
             "source": "/next24",
-            "destination": "/survey",
+            "destination": "https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24?Q_lang=EN",
             "type": 302
           }
       ]

--- a/firebase.json
+++ b/firebase.json
@@ -171,7 +171,7 @@
           },
           {
             "source": "/next24",
-            "destination": "https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24?Q_lang=EN",
+            "destination": "https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24",
             "type": 302
           }
       ]

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -37,4 +37,4 @@
 /dora-report-2016,/research/2017-and-earlier/2016-state-of-devops-report.pdf,302
 /dora-report-2015,/research/2017-and-earlier/2015-state-of-devops-report.pdf,302
 /dora-report-2014,/research/2017-and-earlier/2014-state-of-devops-report.pdf,302
-/next24,https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24?Q_lang=EN,302
+/next24,https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24,302

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -37,4 +37,4 @@
 /dora-report-2016,/research/2017-and-earlier/2016-state-of-devops-report.pdf,302
 /dora-report-2015,/research/2017-and-earlier/2015-state-of-devops-report.pdf,302
 /dora-report-2014,/research/2017-and-earlier/2014-state-of-devops-report.pdf,302
-/next24,/survey,302
+/next24,https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24?Q_lang=EN,302


### PR DESCRIPTION
This PR adds a redirect from path `/next24` to `https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24?Q_lang=EN`

Preview at https://staging.dora.dev/next24