### PR TITLE
suppress site banner in quick check kiosk mode

### DIFF
--- a/hugo/content/quickcheck/kiosk/_index.md
+++ b/hugo/content/quickcheck/kiosk/_index.md
@@ -13,6 +13,7 @@ draft: false
     }
     footer {display:none}
     header {display:none}
+    .site-banner {display:none}
 </style>
 
 <meta name="displayMode" content="kiosk" />


### PR DESCRIPTION
In kiosk mode, the `site-banner` element obscures the content. add CSS to suppress it.