### PR TITLE
Update links to "how to transform" Guide

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -182,7 +182,7 @@
                 {
                     "source": "/devops-capabilities/cultural/devops-culture-transform/",
                     "destination": "/guides/devops-culture-transform/",
-                    "type": 302
+                    "type": 301
                 }
             ]
         }

--- a/hugo/content/devops-capabilities/_index.md
+++ b/hugo/content/devops-capabilities/_index.md
@@ -4,6 +4,6 @@ bannerTitle: Capability catalog
 bannerSubtitle: |
     Explore the technical, process, and cultural capabilities which drive higher software delivery and organizational performance. Each of the articles below presents a capability, discusses how to implement it, and how to overcome common obstacles. 
     
-    You can also learn how to deploy a program to implement these capabilities in our article ["How to Transform."](/devops-capabilities/cultural/devops-culture-transform/)
+    You can also learn how to deploy a program to implement these capabilities in our article ["How to Transform."](/guides/devops-culture-transform/)
 ---
 

--- a/hugo/content/devops-capabilities/cultural/transformational-leadership/index.md
+++ b/hugo/content/devops-capabilities/cultural/transformational-leadership/index.md
@@ -155,7 +155,7 @@ consistent way without having to look it up.
 -   For links to other articles and resources, see the
     [DevOps page](https://cloud.google.com/devops).
 -   Read [*Leadership and Performance Beyond Expectations*](https://books.google.com/books/about/Leadership_and_Performance_Beyond_Expect.html?id=NCd-QgAACAAJ) by Bernad M. Bass (Free Press, 1985.)
--   Check out the article [How to effectively execute transformations.](/devops-capabilities/cultural/devops-culture-transform)
+-   Check out the article [How to transform your organization.](/guides/devops-culture-transform)
 -   Explore our DevOps
     [research program](https://www.devops-research.com/research.html).
 -   Take the

--- a/hugo/content/devops-capabilities/process/visual-management/index.md
+++ b/hugo/content/devops-capabilities/process/visual-management/index.md
@@ -56,7 +56,7 @@ pitfalls when implementing visual management include the following:
     will be used more often. In addition, if teams can have input into the
     metrics that are displayed on their visual displays by participating in
     selecting their goals (for example, some teams
-    [use OKRs](/devops-capabilities/cultural/devops-culture-transform/)),
+    [use OKRs](/guides/devops-culture-transform/)),
     they will be more motivated to drive progress toward those goals.
 -   **Creating displays that are complex, hard to understand, or do not
     provide actionable information**. It's easy to create displays using tools

--- a/hugo/content/devops-capabilities/technical/cloud-infrastructure/index.md
+++ b/hugo/content/devops-capabilities/technical/cloud-infrastructure/index.md
@@ -185,7 +185,7 @@ There will be many obstacles on this journey to overcome, including:
     non-cloud-based systems, including mainframes and packaged software/COTS
 
 Overcoming these obstacles requires a
-[substantial change program](/devops-capabilities/cultural/devops-culture-transform)
+[substantial change program](/guides/devops-culture-transform)
 involving sustained investment and collaboration between people at every level
 of the organization.
 


### PR DESCRIPTION
The "how to transform" article has been moved out of Capabilities, into Guides. This PR updates the intra-site links.

Preview at https://doradotdev-staging--pr577-drafts-on-28lelabr.web.app/devops-capabilities/ (see link in header text)

Redirect from old link (was `302`, now `301`): https://staging.dora.dev/devops-capabilities/cultural/devops-culture-transform/