### PR TITLE
Remove "research archives" / tab redirect

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -80,11 +80,6 @@
                     "type": 302
                 },
                 {
-                    "source": "/research/:year/?tab_archives=:tab",
-                    "destination": "/research/:year/:tab",
-                    "type": 302
-                },
-                {
                     "source": "/dora-report",
                     "destination": "/report",
                     "type": 302

--- a/test/redirects/test-redirects.js
+++ b/test/redirects/test-redirects.js
@@ -34,9 +34,3 @@ describe(`Redirects for ${baseUrl}`, () => {
     });
   });
 });
-
-// TODO:
-// Handle this case
-// "source": "/research/:year/?tab_archives=:tab",
-// "destination": "/research/:year/:tab",
-// "type": 302


### PR DESCRIPTION
This redirect isn't working and is not essential. Remove it in the name of tidiness.