### PR TITLE
Add `/sponsors` page

### DIFF
--- a/hugo/assets/scss/guides.scss
+++ b/hugo/assets/scss/guides.scss
@@ -27,12 +27,3 @@
     color:$color-text-light;
     font-weight:200;
 }
-
-main li {
-    font-family: $font-roboto;
-    font-weight: 300;
-
-    strong {
-        font-family: $font-google-sans;
-    }
-}

--- a/hugo/content/sponsors/index.md
+++ b/hugo/content/sponsors/index.md
@@ -1,0 +1,47 @@
+---
+title: "Partner with DORA"
+date: 2024-04-24T09:58:12-04:00
+draft: false
+bannerTitle: Sponsor DORA research
+bannerSubtitle: Partner with DORA and Google Cloud to shape the future of software development
+---
+Software delivery and operational performance are critical to driving organizational success.  At DORA, we've been at the forefront of research in this field for over a decade, providing data-driven insights that empower organizations to improve their technology practices.
+
+### DORA's annual survey and research program is underway and we'd like to partner with you to bring our findings to the industry.
+
+The 2024 DORA report, presented by Google Cloud, will provide critical insights into the evolving landscape of software development, with a focus on the impact of artificial intelligence, developer experience, and platform engineering on key outcomes like:
+
+* **Software delivery performance:** How quickly and reliably teams can deliver software changes.
+* **Organizational performance:** How effectively organizations achieve their business goals.
+* **Team well-being:** How work practices and culture impact the well-being of software development teams.
+
+By becoming a sponsor of the 2024 DORA report, you have the unique opportunity to partner with Google Cloud and the DORA team to shape the future of software development. This partnership offers you the chance to actively promote the 2024 survey and report, amplifying its reach and impact within the industry.
+
+### By becoming a sponsor of the 2024 DORA Report, you can:
+
+* **Reach a targeted audience:** Gain visibility among thoughts of technology professionals including decision-makers, practitioners, and influencers who rely on DORA's research to guide their strategies.
+* **Demonstrate thought leadership:** Showcase your commitment to innovation and excellence in software development and operations.
+* **Amplify your brand:** Associate with DORA's trusted and respected research, strengthening your reputation as a leader in the industry.
+
+### We offer various sponsorship levels to suit your needs and budget:
+
+#### Premiere (Limited Availability)
+* Prominent logo placement on the report cover.
+* Exclusive right to gate the report on your website 30 days after launch.
+* Report author participation in a sponsored webinar, with opportunity for extended discussion and Q&A.
+
+#### Gold
+* Logo placement on the report cover.
+* Report author participation in a sponsored webinar.
+
+#### Silver
+* Logo in the report.
+* Report author participation in a sponsored webinar.
+
+The DORA Report's influence continues to grow, with the 2023 report reaching tens of thousands of professionals and generating significant industry buzz. By joining us as a sponsor, you can leverage this momentum and position your company at the forefront of helping technology-driven organizations thrive.
+
+### Partnership and Community
+Beyond these tangible benefits, all potential sponsors are invited to join the vibrant [DORA Community](https://dora.community) This community provides a platform for sharing experiences, learning from others, and collaborating on initiatives to improve software delivery and operations performance.
+
+### Take Action:
+For more information, contact us at [sponsor-dora@google.com](mailto:sponsor-dora@google.com).

--- a/hugo/themes/dora/assets/scss/main.scss
+++ b/hugo/themes/dora/assets/scss/main.scss
@@ -36,6 +36,16 @@ body {
         padding: 1.5rem 4rem 0.5rem 4rem;
         margin: auto;
 
+        li {
+            font-family: $font-roboto;
+            font-weight: 300;
+        
+            strong, b, a {
+                font-family: $font-google-sans;
+                font-weight: 500;
+            }
+        }
+
         @include media-medium {
             padding: 0.75em;
             width: auto;


### PR DESCRIPTION
This PR adds a page at `/sponsors` containing information for organizations about sponsoring the 2024 State of DevOps Report.

It also promotes the fix for #563 to apply to all pages.

Preview at https://doradotdev-staging--pr584-drafts-on-yq38sfij.web.app/sponsors/

Fixes #583 