### PR TITLE
Add a trailing `/` to fix a failing test

### DIFF
--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -40,4 +40,4 @@
 /next24,https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=next24,302
 /devops-capabilities/cultural/how-to-empower-software-delivery-teams/,/guides/how-to-empower-software-delivery-teams/,302
 /devops-capabilities/cultural/devops-culture-transform/,/guides/devops-culture-transform/,301
-/sponsor,/sponsors,301
+/sponsor,/sponsors/,301


### PR DESCRIPTION
`/sponsor` redirects to `/sponsors/`, not `/sponsors`