### PR TITLE
update search page to use search.dora.dev

### DIFF
--- a/hugo/content/search/_index.md
+++ b/hugo/content/search/_index.md
@@ -4,14 +4,64 @@ date: 2024-02-15T18:39:17-05:00
 draft: true
 ---
 
-<!-- Widget JavaScript bundle -->
-<script src="https://cloud.google.com/ai/gen-app-builder/client?hl=en_GB"></script>
+## TEST page for search.dora.dev
 
-<!-- Search widget element is not visible by default -->
-<gen-search-widget
-  configId="5d106d06-fe17-4a26-ad53-19a84e72004b"
-  triggerId="searchWidgetTrigger">
-</gen-search-widget>
+<script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+        let searchServer="https://search.dora.dev/";
+        let inputBox = document.querySelector("#searchQuery");
+        let resultsBox = document.querySelector('#searchResults');
+        let searchURI = '';
 
-<!-- Element that opens the widget on click. It does not have to be an input -->
-<input placeholder="Search here" id="searchWidgetTrigger" />
+        function makeDelay(ms) {
+            var timer = 0;
+            return function(callback){
+                clearTimeout (timer);
+                timer = setTimeout(callback, ms);
+            };
+        };
+        
+
+        inputBox.addEventListener('keyup', (event) => {
+            if(inputBox.value.length >= 3) {
+                query(inputBox.value)
+            }
+        })
+
+        function query(searchTerm) {
+            console.log(`searching ${searchTerm}...`)
+            searchURI = `${searchServer}?query=${searchTerm}`;
+            fetch(searchURI)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    resultsBox.innerHTML = '';
+                    data.forEach((result) => {
+                        thisResult = `
+                            <div>
+                                <div><a href="${result.link}">${result.title}</a></div>
+                                <div>
+                                    ${result.snippet}
+                                </div>
+                            </div>
+                            `;
+                        resultsBox.innerHTML += thisResult;
+                    })
+
+                })
+                .catch(error => {
+                    resultsBox.innerHTML = "(error fetching search results)"
+                });
+        }
+    });
+</script>
+
+<input type="text" name="query" id="searchQuery" placeholder="(enter a search query)">
+
+<div id="searchResults" style="width:80%;border:1px solid grey;padding:.5rem;height:40rem;overflow-y:auto">
+    (results will appear here)
+</div>


### PR DESCRIPTION
This PR updates the `/search` page to reference the new [search.dora.dev](https://github.com/dora-team/search.dora.dev) service.

The page is only visible when hugo's `--buildDrafts` flag is passed. (So it's not visible on prod.)

preview at
https://doradotdev-staging--pr599-drafts-on-4anxawsx.web.app/search/