### PR TITLE
add core 2 preview link

### DIFF
--- a/hugo/layouts/research/section.html
+++ b/hugo/layouts/research/section.html
@@ -98,6 +98,9 @@
     {{ with $png }}
         <a href="{{ .RelPermalink }}" class="button secondary" download>Download as PNG</a>
     {{ end }}
+    <blockquote>
+        Preview the next version of the DORA Core model: <a href="https://github.com/dora-team/dora.dev/discussions/582" target="_blank">DORA Core V2 (proposal)</a>
+    </blockquote>
 </div>
 
     <h3 id="dora_research_archives">DORA Research Archives</h3>


### PR DESCRIPTION
Core V2 is available for public feedback. Let's link to it from dora.dev

Preview:
https://doradotdev-staging--pr600-drafts-on-10ivnz9c.web.app/research/