### PR TITLE
Uniform gutters on the quick check page

### DIFF
--- a/hugo/themes/dora/assets/scss/main.scss
+++ b/hugo/themes/dora/assets/scss/main.scss
@@ -30,7 +30,6 @@ body {
     letter-spacing: 0.2px;
 
     main {
-        width: 100%;
         flex-grow: 1;
         max-width: $layout-breakpoint-max;
         padding: 1.5rem 4rem 0.5rem 4rem;

--- a/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
+++ b/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
@@ -289,7 +289,7 @@
                 width: calc(100% - 1rem);
                 padding: 0.5rem;
                 label {
-                    padding-inline: 0.5rem;
+                    padding-left: 0.5rem;
                 }
             }
         }

--- a/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
+++ b/svelte/quick-check-2023/src/lib/MetricsQuestion.svelte
@@ -165,7 +165,7 @@
 
         label {
             margin-bottom: 6px;
-            padding-left: 0.5rem;
+            padding-inline: 0.5rem;
         }
 
         slider {
@@ -286,10 +286,10 @@
             }
 
             fieldset {
-                width: 100%;
+                width: calc(100% - 1rem);
                 padding: 0.5rem;
                 label {
-                    padding-left: 0.5rem;
+                    padding-inline: 0.5rem;
                 }
             }
         }


### PR DESCRIPTION
Brings equal gutters on smaller devices.

Hopefully improves things for #534 

# Before

![Text meets edge, and overflows on very small devices](https://github.com/dora-team/dora.dev/assets/99181436/c7b59fae-a342-48bd-8a4e-bd8ed8e30201)

# After

![Even gutters](https://github.com/dora-team/dora.dev/assets/99181436/e21af958-61ca-481b-a475-43989dd7dc65)
