### PR TITLE
Add language options for 2023 report

### DIFF
--- a/hugo/content/research/2023/dora-report/index.md
+++ b/hugo/content/research/2023/dora-report/index.md
@@ -10,4 +10,27 @@ type: "research_archives"
 ---
 ## Download the 2023 DORA Report
 
+<grid class="border_none" style="margin-top:1rem;">
+<item>
+
 <a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><img src="2023-dora-accelerate-state-of-devops-report.png" style="max-width:24em;"></a>
+
+</item>
+<item>
+
+#### The 2023 DORA Report is available in the following languages:
+
+<ul>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=en&region=US" target="_blank">English</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=es&region=ES" target="_blank">Español</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=es-419&region=MX" target="_blank">Español - América Latina</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=fr&region=FR" target="_blank">Français</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=it&region=IT" target="_blank">Italiano</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=pt-br&region=BR" target="_blank">Português - Brasil</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW" target="_blank">中文 – 简体</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=ja&region=JP" target="_blank">日本語</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=ko&region=KR" target="_blank">한국어</a></li>
+</ul>
+
+</item>
+</grid>

--- a/test/playwright/tests/2023-report.spec.ts
+++ b/test/playwright/tests/2023-report.spec.ts
@@ -1,0 +1,18 @@
+const { test, expect } = require('@playwright/test');
+
+test('Verify the page title', async ({ page }) => {
+  await page.goto('/research/2023/dora-report/');
+  await expect(page).toHaveTitle('DORA | Accelerate State of DevOps Report 2023');
+});
+
+test('Verify the download button text', async ({ page }) => {
+  await page.goto('/research/2023/dora-report/');
+  const downloadButton = await page.locator('text=Download the 2023 DORA Report');
+  await expect(downloadButton).toBeVisible();
+});
+
+test('Verify the language options', async ({ page }) => {
+  await page.goto('/research/2023/dora-report/');
+  const languageOptions = await page.locator('item ul li').count();
+  await expect(languageOptions).toBe(9);
+});


### PR DESCRIPTION
* Add links to download the report in the 9 available languages
* Add playwright tests for the 2023 report page

Fixes #622

Preview:  https://doradotdev-staging--pr623-drafts-off-esz59fls.web.app/research/2023/dora-report/