### PR TITLE
Add support for code blocks  (Fixes #629)

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -4,8 +4,12 @@ theme = 'dora'
 rssLimit = 10
 ignoreFiles = "README.md"
 
-[markup.goldmark.renderer]
-unsafe= true
+[markup]
+    [markup.highlight]
+        noClasses = false
+
+    [markup.goldmark.renderer]
+        unsafe= true
 
 [params]
     Keywords = "DevOps, Lead time, Deploy frequency, Change fail rate, MTTR, Time to restore, metrics, DORA"

--- a/hugo/content/misc/code.md
+++ b/hugo/content/misc/code.md
@@ -1,0 +1,38 @@
+---
+title: "Code"
+date: 2024-06-03T11:09:40-04:00
+draft: true
+---
+
+## This is a dummy page (in draft mode; it will not render on prod) used to show how code blocks render
+### Hugo uses the Chroma syntax highlighter, and we've chosen Chroma's `friendly` style, with some small additional tweaks
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis quis arcu imperdiet, semper metus quis, efficitur magna. Morbi malesuada enim nec justo malesuada, sed vulputate nisi feugiat. Etiam quis velit eu sapien fermentum fermentum. Maecenas lacinia et eros et fringilla. Etiam volutpat, tellus ut volutpat porttitor, magna massa commodo nunc, sed egestas neque turpis in diam. Ut ut quam in nisl tincidunt fringilla in rutrum dui. In a nibh elit. Ut commodo viverra pulvinar.
+
+```python
+# Random snippet of code (from TensorFlow examples)
+import argparse
+
+import numpy as np
+import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
+
+def load_graph(model_file):
+  graph = tf.Graph()
+  graph_def = tf.compat.v1.GraphDef()
+
+  with open(model_file, "rb") as f:
+    graph_def.ParseFromString(f.read())
+  with graph.as_default():
+    tf.import_graph_def(graph_def)
+
+  return graph
+```
+
+Ut est quam, pulvinar at pretium ut, pharetra commodo ante. Duis hendrerit odio sit amet ullamcorper sodales. Praesent euismod nunc ut nisi convallis, sit amet volutpat lacus venenatis. Fusce id sodales ligula. Aenean eleifend metus lacus, non eleifend turpis molestie a. Morbi risus lorem, tempor id lacinia eget, euismod sit amet ligula. Cras molestie accumsan commodo. Duis feugiat at nulla sodales luctus. Vestibulum vitae tristique orci, vitae lacinia eros. Proin varius nunc at maximus fermentum. Mauris at eros tincidunt, vehicula justo elementum, tristique augue. Morbi sit amet ligula augue. Praesent nec urna nec massa iaculis consequat nec non tortor. Aliquam ultrices dui purus, sed dictum lectus facilisis ut. Maecenas at est id risus feugiat semper.
+
+Nullam tempus turpis sed justo elementum, non interdum nulla finibus. Donec id erat at quam auctor iaculis. Cras commodo, magna id finibus dictum, mi dolor mollis ipsum, vel egestas sapien sem tristique ante. Nam maximus sapien eu lorem placerat imperdiet. Nulla ornare semper nibh, finibus aliquet arcu rutrum in. Mauris laoreet, mauris sed euismod molestie, dolor mi mattis massa, quis semper eros ipsum eget arcu. Morbi gravida vitae odio vel lobortis.
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aenean vel est consequat, finibus felis et, scelerisque orci. Vestibulum elementum suscipit sollicitudin. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Phasellus mollis arcu sed ante commodo, a pulvinar eros placerat. Sed a efficitur felis. Vestibulum sollicitudin dictum euismod. Vestibulum sed odio et orci imperdiet porta in eget ex. Donec sapien lacus, maximus in quam at, suscipit iaculis purus. Etiam mollis pretium pharetra. Cras vulputate ultricies nisl vitae maximus. Praesent nec mauris facilisis, ultrices risus vitae, facilisis tellus.
+
+Etiam congue nisi odio, sed consectetur erat venenatis ac. Etiam scelerisque ante nulla, non malesuada dui dictum vitae. Mauris molestie nulla eget gravida lacinia. Phasellus vel bibendum nisi, eu lacinia sem. Nulla ut enim et nibh vulputate gravida eget sit amet nunc. Mauris blandit erat tellus. Proin erat dolor, tincidunt eget ante a, fringilla vehicula lectus. Aenean imperdiet risus a malesuada vehicula. Cras sit amet turpis vel tellus lacinia bibendum. Quisque consequat sapien vitae mi efficitur ultrices. Ut et tincidunt sapien, vel facilisis libero.

--- a/hugo/themes/dora/assets/scss/main.scss
+++ b/hugo/themes/dora/assets/scss/main.scss
@@ -12,6 +12,7 @@
 @import "widgets.scss";
 @import "sidebar.scss";
 @import "footer.scss";
+@import "syntax-dora.scss";
 
 html {
     scrollbar-gutter: stable;

--- a/hugo/themes/dora/assets/scss/syntax-dora.scss
+++ b/hugo/themes/dora/assets/scss/syntax-dora.scss
@@ -1,0 +1,8 @@
+/* This file wraps 'syntax.scss' which is generated via `hugogen chromastyles` */
+
+@import "syntax.scss";
+
+pre:has(code) {
+    border-radius: 1em;
+    padding:1.5em;
+}

--- a/hugo/themes/dora/assets/scss/syntax.scss
+++ b/hugo/themes/dora/assets/scss/syntax.scss
@@ -1,0 +1,86 @@
+/* Background */ .bg { background-color: #f0f0f0; }
+/* PreWrapper */ .chroma { background-color: #f0f0f0; }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err {  }
+/* CodeLine */ .chroma .cl {  }
+/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: #007020; font-weight: bold }
+/* KeywordConstant */ .chroma .kc { color: #007020; font-weight: bold }
+/* KeywordDeclaration */ .chroma .kd { color: #007020; font-weight: bold }
+/* KeywordNamespace */ .chroma .kn { color: #007020; font-weight: bold }
+/* KeywordPseudo */ .chroma .kp { color: #007020 }
+/* KeywordReserved */ .chroma .kr { color: #007020; font-weight: bold }
+/* KeywordType */ .chroma .kt { color: #902000 }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na { color: #4070a0 }
+/* NameBuiltin */ .chroma .nb { color: #007020 }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: #0e84b5; font-weight: bold }
+/* NameConstant */ .chroma .no { color: #60add5 }
+/* NameDecorator */ .chroma .nd { color: #555555; font-weight: bold }
+/* NameEntity */ .chroma .ni { color: #d55537; font-weight: bold }
+/* NameException */ .chroma .ne { color: #007020 }
+/* NameFunction */ .chroma .nf { color: #06287e }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl { color: #002070; font-weight: bold }
+/* NameNamespace */ .chroma .nn { color: #0e84b5; font-weight: bold }
+/* NameOther */ .chroma .nx {  }
+/* NameProperty */ .chroma .py {  }
+/* NameTag */ .chroma .nt { color: #062873; font-weight: bold }
+/* NameVariable */ .chroma .nv { color: #bb60d5 }
+/* NameVariableClass */ .chroma .vc {  }
+/* NameVariableGlobal */ .chroma .vg {  }
+/* NameVariableInstance */ .chroma .vi {  }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l {  }
+/* LiteralDate */ .chroma .ld {  }
+/* LiteralString */ .chroma .s { color: #4070a0 }
+/* LiteralStringAffix */ .chroma .sa { color: #4070a0 }
+/* LiteralStringBacktick */ .chroma .sb { color: #4070a0 }
+/* LiteralStringChar */ .chroma .sc { color: #4070a0 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #4070a0 }
+/* LiteralStringDoc */ .chroma .sd { color: #4070a0; font-style: italic }
+/* LiteralStringDouble */ .chroma .s2 { color: #4070a0 }
+/* LiteralStringEscape */ .chroma .se { color: #4070a0; font-weight: bold }
+/* LiteralStringHeredoc */ .chroma .sh { color: #4070a0 }
+/* LiteralStringInterpol */ .chroma .si { color: #70a0d0 }
+/* LiteralStringOther */ .chroma .sx { color: #c65d09 }
+/* LiteralStringRegex */ .chroma .sr { color: #235388 }
+/* LiteralStringSingle */ .chroma .s1 { color: #4070a0 }
+/* LiteralStringSymbol */ .chroma .ss { color: #517918 }
+/* LiteralNumber */ .chroma .m { color: #40a070 }
+/* LiteralNumberBin */ .chroma .mb { color: #40a070 }
+/* LiteralNumberFloat */ .chroma .mf { color: #40a070 }
+/* LiteralNumberHex */ .chroma .mh { color: #40a070 }
+/* LiteralNumberInteger */ .chroma .mi { color: #40a070 }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #40a070 }
+/* LiteralNumberOct */ .chroma .mo { color: #40a070 }
+/* Operator */ .chroma .o { color: #666666 }
+/* OperatorWord */ .chroma .ow { color: #007020; font-weight: bold }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #60a0b0; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #60a0b0; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #60a0b0; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #60a0b0; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #60a0b0; background-color: #fff0f0 }
+/* CommentPreproc */ .chroma .cp { color: #007020 }
+/* CommentPreprocFile */ .chroma .cpf { color: #007020 }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color: #a00000 }
+/* GenericEmph */ .chroma .ge { font-style: italic }
+/* GenericError */ .chroma .gr { color: #ff0000 }
+/* GenericHeading */ .chroma .gh { color: #000080; font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #00a000 }
+/* GenericOutput */ .chroma .go { color: #888888 }
+/* GenericPrompt */ .chroma .gp { color: #c65d09; font-weight: bold }
+/* GenericStrong */ .chroma .gs { font-weight: bold }
+/* GenericSubheading */ .chroma .gu { color: #800080; font-weight: bold }
+/* GenericTraceback */ .chroma .gt { color: #0044dd }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #bbbbbb }


### PR DESCRIPTION
This PR creates a stylesheet for use with code blocks. Within a markdown file, code blocks are created using standard syntax (surround code with three backticks, and an optional language specifier).

Preview at:
https://doradotdev-staging--pr630-drafts-on-8gyd2auv.web.app/misc/code/

Fixes #629