### PR TITLE
DORA links should link to dora.dev

### DIFF
--- a/hugo/content/devops-capabilities/process/team-experimentation/index.md
+++ b/hugo/content/devops-capabilities/process/team-experimentation/index.md
@@ -36,7 +36,7 @@ performance.
 
 ## How to implement team experimentation
 
-[DevOps Research and Assessment (DORA) research](https://cloud.google.com/devops)
+[DevOps Research and Assessment (DORA) research](https://dora.dev)
 identifies three key components to team experimentation that drive software
 delivery performance:
 

--- a/hugo/content/devops-capabilities/technical/code-maintainability/index.md
+++ b/hugo/content/devops-capabilities/technical/code-maintainability/index.md
@@ -16,7 +16,7 @@ to run the systems we build: The Android operating system runs on 12 to 15
 million lines of code, Google's monolithic code repository contains over 1
 billion lines of code, and a typical smartphone app has 50,000 lines of code.
 
-The 2019 State of DevOps Report from [DevOps Research and Assessment (DORA)](https://cloud.google.com/devops) research shows that the ability of teams to maintain their code
+The 2019 State of DevOps Report from [DevOps Research and Assessment (DORA)](https://dora.dev) research shows that the ability of teams to maintain their code
 effectively is one of a number of technical practices that contribute positively
 to success with
 [continuous delivery](/devops-capabilities/technical/continuous-delivery).

--- a/hugo/content/devops-capabilities/technical/continuous-delivery/index.md
+++ b/hugo/content/devops-capabilities/technical/continuous-delivery/index.md
@@ -66,7 +66,7 @@ domains. Continuous delivery has been successfully applied many times in highly
 regulated domains such as financial services and government.
 
 Although continuous delivery is possible for all kinds of software, it is hard
-work. Nevertheless it provides significant benefits. [DevOps Research and Assessment (DORA)](https://cloud.google.com/devops) research shows that doing well at continuous delivery provides
+work. Nevertheless it provides significant benefits. [DevOps Research and Assessment (DORA)](https://dora.dev) research shows that doing well at continuous delivery provides
 the following benefits:
 
 -   Improves software delivery performance, measured in terms of the
@@ -293,7 +293,7 @@ time spent doing rework and unplanned work.
 ## What's next
 
 -  For links to other articles and resources, see the
-    [DevOps page](https://cloud.google.com/devops).
+    [DevOps page](https://dora.dev).
 -  Learn more about continuous delivery in Martin Fowler's
     [Software delivery guide](https://martinfowler.com/delivery.html).
 -   Read [*Value Stream Mapping: How to Visualize Work and Align Leadership for Organizational Transformation*](https://books.google.com/books/about/Value_Stream_Mapping_How_to_Visualize_Wo.html?id=ll7imAEACAAJ) by Karen Martin and Mike Osterling.

--- a/hugo/content/devops-capabilities/technical/test-data-management/index.md
+++ b/hugo/content/devops-capabilities/technical/test-data-management/index.md
@@ -32,7 +32,7 @@ manage your test data carefully and strategically.
 ## How to implement test data management
 
 Analysis done by
-[DevOps Research and Assessment (DORA)](https://cloud.google.com/devops)
+[DevOps Research and Assessment (DORA)](https://dora.dev)
 shows that successful teams approach test data management with the following
 core principles:
 


### PR DESCRIPTION
This updates the capabilities articles that link to https://cloud.google.com/devops so that they now link to the DORA home page.

Preview links:

* https://doradotdev-staging--pr631-drafts-off-e6bvwntd.web.app/devops-capabilities/process/team-experimentation/#how-to-implement-team-experimentation
* https://doradotdev-staging--pr631-drafts-off-e6bvwntd.web.app/devops-capabilities/technical/code-maintainability/
* https://doradotdev-staging--pr631-drafts-off-e6bvwntd.web.app/devops-capabilities/technical/continuous-delivery/
* https://doradotdev-staging--pr631-drafts-off-e6bvwntd.web.app/devops-capabilities/technical/test-data-management/#how-to-implement-test-data-management