### PR TITLE
Add a <nav> element to the footer  (Fixes #640)

### DIFF
--- a/hugo/themes/dora/layouts/partials/footer.html
+++ b/hugo/themes/dora/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer>
-    <div class="linkContainer">
+    <nav class="linkContainer">
         <div class="logo"><a href="https://cloud.google.com/" target="_blank"><img src="/img/cloud-logo-dark.svg"></a></div>
         <div class="links">
             <span class="linkGroup">
@@ -13,7 +13,7 @@
                 <a class="google-material-icons divider-before" href="https://github.com/dora-team/dora.dev" target="_blank" aria-label="This site's source code">github</a>
             </span>
         </div>
-    </div>
+    </nav>
     <div class="content-license">
         <strong>DORA is a program run by Google Cloud.</strong> 
         All content on this site is licensed by Google LLC under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>, unless otherwise specified.


### PR DESCRIPTION
This PR changes a `<div>` element in the footer to `<nav>` -- visually, there's no change, but the semantic `nav` element is preferable for accessibility, and I'm hopeful that it might help with the problem of navigation elements sneaking into search results (see below). _Caveat:_ if it _does_ help that problem, it won't help until the search crawler has had a chance to re-index the site and IDK when that will happen. So let's make this change, and then wait and hope. 😄 

![image](https://github.com/dora-team/dora.dev/assets/2166159/6bad31b1-ead6-4ce8-a62d-9390b49c471d)



Fixes #640