### PR TITLE
Improve language on prioritization exercise (Fixes #627)

### DIFF
--- a/svelte/quick-check-2023/src/lib/Capability.svelte
+++ b/svelte/quick-check-2023/src/lib/Capability.svelte
@@ -52,7 +52,7 @@
     <table>
         <thead>
             <tr>
-                <th>For the primary application or service you work on:</th>
+                <th>{capability.response_prompt}</th>
                 {#each response_options as option}
                     <th>{option}</th>
                 {/each}

--- a/svelte/quick-check-2023/src/lib/data/capability_prioritization_questions.json
+++ b/svelte/quick-check-2023/src/lib/data/capability_prioritization_questions.json
@@ -5,6 +5,7 @@
         "shortname": "ci",
         "description": "Continuous integration (CI) is the first step towards continuous delivery. This is a development practice where code is regularly checked in, and each check-in triggers a set of quick tests to discover serious regressions, which developers fix immediately. The CI process creates canonical builds and packages that are ultimately deployed and released.",
         "article_url": "/devops-capabilities/technical/continuous-integration/",
+        "response_prompt": "For the primary application or service you work on:",
         "questions": [
             {
                 "number": 1,
@@ -34,6 +35,7 @@
         "shortname": "arch",
         "description": "Architecture that lets teams test and deploy their applications on demand, without requiring orchestration with other services. Having a loosely coupled architecture allows your teams to work independently without relying on other teams for support and services, which in turn enables them to work quickly and deliver value to the organization.",
         "article_url": "/devops-capabilities/technical/loosely-coupled-architecture/",
+        "response_prompt": "",
         "questions": [
             {
                 "number": 1,
@@ -67,6 +69,7 @@
         "shortname": "culture",
         "description": "Westrum's measure of organizational culture is predictive of IT performance, organizational performance, and decreasing burnout. Hallmarks of this measure include good information flow, high cooperation and trust, bridging between teams, and conscious inquiry.",
         "article_url": "/devops-capabilities/cultural/generative-organizational-culture/",
+        "response_prompt": "In my organization...",   
         "questions": [
             {
                 "number": 1,


### PR DESCRIPTION
This PR updates the headings on the "help me prioritize" questions - it switches the culture questions to start with "in my organization..." and removes the heading from the LCA questions because those contain their own contexts.

Preview: https://doradotdev-staging--pr642-drafts-on-godc4w1m.web.app/quickcheck/?leadtime=2&deployfreq=5&changefailure=30&failurerecovery=2&v=2023&industry=all#whats-holding-you-back

Fixes #627