### PR TITLE
bug(guides): Update banner subtitle to use "practitioners"

### DIFF
--- a/hugo/content/guides/_index.md
+++ b/hugo/content/guides/_index.md
@@ -4,5 +4,5 @@ date: 2024-03-29T16:06:31-04:00
 draft: false
 bannerTitle: "DORA Guides"
 bannerSubtitle: |
-    For a successful journey of continuous improvement—getting better at getting better!—you'll need the right equipment. These guides, written by members of the DORA research project and friends from throughout our <a href="https://dora.community/" target="_blank">community of practice</a>, offer advice from practioners on how to apply DORA's findings in your own unique context. 
+    For a successful journey of continuous improvement—getting better at getting better!—you'll need the right equipment. These guides, written by members of the DORA research project and friends from throughout our <a href="https://dora.community/" target="_blank">community of practice</a>, offer advice from practitioners on how to apply DORA's findings in your own unique context. 
 ---


### PR DESCRIPTION
This trivial fix updates the banner subtitle on the DORA guides page to spell "practitioners" correctly instead of the misspelled "practioners".

Preview:  https://doradotdev-staging--pr653-drafts-off-nn5oxgyl.web.app/guides