### PR TITLE
Update 2024 DORA survey page

### DIFF
--- a/hugo/content/research/2024/_index.md
+++ b/hugo/content/research/2024/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "DORA Research: 2024"
-date: 2024-06-06
+date: 2024-07-02
 draft: false
 research_year: "2024"
 type: "research_archives"
@@ -9,17 +9,15 @@ tab_title: "Overview"
 layout: single
 ---
 
-[![2024 DORA Survey - Shape the future of tech](/survey/1920x1080_survey_future_white.png)](https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=doradotdev-survey)
+Thank you to everyone who took the time to participate in the 2024 DORA survey!
 
-**The survey is now open!** Take a moment to reflect on your work, and share your experience to enrich this year's research. Most participants are able to complete the survey in about 15 minutes.
+Your responses are being analyzed and will provide the basis for this year's DORA Report.
 
 ### What's new for 2024?
 
 * **Artificial Intelligence (AI)** - Last year we asked the importance of AI in your daily work. This year we are expanding our inquiry in this area to better understand how AI is changing your work and the impact of those changes. How is AI impacting organizational performance?
 * **Platform Engineering** - We want to better understand how your organization is approaching platform engineering. Platform engineering may include both technologies and teams. How does platform engineering impact software delivery performance?
 * **Developer Experience** - We want to learn more about your overall experience as you work to deliver for your customers. How does your experience impact the value you're able to deliver?
-
-{{< button href="https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=doradotdev-survey" target="_blank" >}}Take the 2024 DORA Survey now!{{< /button >}}
 
 
 <!--

--- a/hugo/content/survey/_index.md
+++ b/hugo/content/survey/_index.md
@@ -4,17 +4,16 @@ date: 2024-04-08T23:26:21Z
 draft: false
 ---
 
-[![2024 DORA Survey - Shape the future of tech](1920x1080_survey_future_white.png)](https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=doradotdev-survey)
+# The 2024 DORA Survey is now closed
+Thank you to everyone who took the time to participate in the 2024 DORA survey!
 
-**The survey is now open!** Take a moment to reflect on your work, and share your experience to enrich this year's research. Most participants are able to complete the survey in about 15 minutes.
+Your responses are being analyzed and will provide the basis for this year's DORA Report.
 
 ### What's new for 2024?
 
 * **Artificial Intelligence (AI)** - Last year we asked the importance of AI in your daily work. This year we are expanding our inquiry in this area to better understand how AI is changing your work and the impact of those changes. How is AI impacting organizational performance?
 * **Platform Engineering** - We want to better understand how your organization is approaching platform engineering. Platform engineering may include both technologies and teams. How does platform engineering impact software delivery performance?
 * **Developer Experience** - We want to learn more about your overall experience as you work to deliver for your customers. How does your experience impact the value you're able to deliver?
-
-{{< button href="https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=doradotdev-survey" target="_blank" >}}Take the 2024 DORA Survey now!{{< /button >}}
 
 
 <!--

--- a/hugo/layouts/partials/site_banner.html
+++ b/hugo/layouts/partials/site_banner.html
@@ -1,5 +1,3 @@
-{{ if not (eq .Section "survey") }}
 <div class="site-banner">
-    <a href="https://google.qualtrics.com/jfe/form/SV_8uCHA4aRzcGDjg2?source=doradotdev-banner" target="_blank">Take the 2024 DORA Survey now!</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSfqR-4fS9MlqjhgYmdDcrGqEkGccA_8MJoRXevYO1xJoXSkTA/viewform" target="_blank">Apply for the Google Cloud DORA Awards!</a>
 </div>
-{{ end }}

--- a/test/playwright/tests/2024-research.spec.ts
+++ b/test/playwright/tests/2024-research.spec.ts
@@ -5,10 +5,7 @@ test('Verify the page title', async ({ page }) => {
   await expect(page).toHaveTitle('DORA | DORA Research: 2024');
 });
 
-test('Survey Image', async ({ page }) => {
+test('The 2024 research page heading', async ({ page }) => {
   await page.goto('/research/2024/');
-  const surveyImage = await page.locator('img[alt="2024 DORA Survey - Shape the future of tech"]');
-  const imgSrc = await surveyImage.getAttribute('src');
-  const res = await page.request.get(imgSrc);
-  expect(res.status()).toBe(200);
+  await expect(page.locator('h1')).toContainText('DORA Research: 2024');
 });

--- a/test/playwright/tests/survey.spec.ts
+++ b/test/playwright/tests/survey.spec.ts
@@ -5,11 +5,7 @@ test('Verify the page title', async ({ page }) => {
   await expect(page).toHaveTitle('DORA | The 2024 DORA Survey');
 });
 
-test('Survey Image', async ({ page }) => {
+test('The 2024 survey is closed', async ({ page }) => {
   await page.goto('/survey/');
-  const surveyImage = await page.locator('img[alt="2024 DORA Survey - Shape the future of tech"]');
-  const imgSrc = await surveyImage.getAttribute('src');
-  const res = await page.request.get('/survey/' + imgSrc);
-  expect(res.status()).toBe(200);
+  await expect(page.locator('h1')).toContainText('The 2024 DORA Survey is now closed');
 });
-


### PR DESCRIPTION
This commit updates the 2024 DORA survey page to reflect that the survey is now closed.

The following changes were made:

* Removed the survey banner from the site.
* Removed the survey call to action from the 2024 research page.
* Updated the 2024 research page to indicate that the survey is closed and thank participants.
* Updated the survey page to indicate that the survey is closed and thank participants.

This also adds a banner to apply for the Google Cloud DORA Awards

Preview:
* https://doradotdev-staging--pr668-drafts-off-knf90j9n.web.app/research/2024/
* https://doradotdev-staging--pr668-drafts-off-knf90j9n.web.app/survey/