### PR TITLE
Link to quick check from software delivery performance in core model  (Fixes #682)

### DIFF
--- a/svelte/core-v2/src/lib/Popover.svelte
+++ b/svelte/core-v2/src/lib/Popover.svelte
@@ -143,7 +143,15 @@
 
         .footer {
             text-align: center;
-            padding: 0.5rem;
+            padding: 0 .5rem 1rem .5rem;
+
+            a {
+                border:1px solid var(--color-grey-light);
+                display:inline-block;
+                border-radius: .25rem;
+                padding:.25rem .75rem;
+                text-decoration: none;
+            }
         }
 
         &::backdrop {

--- a/svelte/core-v2/src/lib/core_data.json
+++ b/svelte/core-v2/src/lib/core_data.json
@@ -112,28 +112,28 @@
         "software-delivery": {
             "name": "Software delivery",
             "link": "/guides/dora-metrics-four-keys/",
-            "summary": "DORA’s research has consistently found that a team’s software delivery capability reliably predicts the value that the team provides to their organization. Survey respondents who achieve high levels of software delivery performance report that their organizations perform better on business objectives. Performance can be assessed according to four software delivery metrics.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve.",
+            "summary": "DORA’s research has consistently found that a team’s software delivery capability reliably predicts the value that the team provides to their organization. Survey respondents who achieve high levels of software delivery performance report that their organizations perform better on business objectives. Performance can be assessed according to four software delivery metrics.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck' target='_blank'>DORA Quick Check</a> for insights on how to improve.",
             "measured_by": "Four key metrics",
             "entities": {
                 "changelead": {
                     "name": "Change lead time",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": "This metric measures the time it takes for a code commit or change to be successfully deployed to production. It reflects the efficiency of your delivery pipeline.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
+                    "summary": "This metric measures the time it takes for a code commit or change to be successfully deployed to production. It reflects the efficiency of your delivery pipeline.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck' target='_blank'>DORA Quick Check</a> for insights on how to improve."
                 },
                 "deployfrequency": {
                     "name": "Deployment frequency",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": "This metric measures how often application changes are deployed to production. Higher deployment frequency indicates a more agile and responsive delivery process.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
+                    "summary": "This metric measures how often application changes are deployed to production. Higher deployment frequency indicates a more agile and responsive delivery process.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck' target='_blank'>DORA Quick Check</a> for insights on how to improve."
                 },
                 "changefail": {
                     "name": "Change fail percentage",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": " This metric measures the percentage of deployments that cause failures in production, requiring hotfixes or rollbacks. A lower change failure rate indicates a more reliable delivery process.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
+                    "summary": " This metric measures the percentage of deployments that cause failures in production, requiring hotfixes or rollbacks. A lower change failure rate indicates a more reliable delivery process.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck' target='_blank'>DORA Quick Check</a> for insights on how to improve."
                 },
                 "recoverytime": {
                     "name": "Failed deployment recovery time",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": "This metric measures the time it takes to recover from a failed deployment. A lower recovery time indicates a more resilient and responsive system.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
+                    "summary": "This metric measures the time it takes to recover from a failed deployment. A lower recovery time indicates a more resilient and responsive system.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck' target='_blank'>DORA Quick Check</a> for insights on how to improve."
                 }
             }
         },

--- a/svelte/core-v2/src/lib/core_data.json
+++ b/svelte/core-v2/src/lib/core_data.json
@@ -112,28 +112,28 @@
         "software-delivery": {
             "name": "Software delivery",
             "link": "/guides/dora-metrics-four-keys/",
-            "summary": "DORA’s research has consistently found that a team’s software delivery capability reliably predicts the value that the team provides to their organization. Survey respondents who achieve high levels of software delivery performance report that their organizations perform better on business objectives. Performance can be assessed according to four software delivery metrics:",
+            "summary": "DORA’s research has consistently found that a team’s software delivery capability reliably predicts the value that the team provides to their organization. Survey respondents who achieve high levels of software delivery performance report that their organizations perform better on business objectives. Performance can be assessed according to four software delivery metrics.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve.",
             "measured_by": "Four key metrics",
             "entities": {
                 "changelead": {
                     "name": "Change lead time",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": "This metric measures the time it takes for a code commit or change to be successfully deployed to production. It reflects the efficiency of your delivery pipeline."
+                    "summary": "This metric measures the time it takes for a code commit or change to be successfully deployed to production. It reflects the efficiency of your delivery pipeline.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
                 },
                 "deployfrequency": {
                     "name": "Deployment frequency",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": "This metric measures how often application changes are deployed to production. Higher deployment frequency indicates a more agile and responsive delivery process."
+                    "summary": "This metric measures how often application changes are deployed to production. Higher deployment frequency indicates a more agile and responsive delivery process.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
                 },
                 "changefail": {
                     "name": "Change fail percentage",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": " This metric measures the percentage of deployments that cause failures in production, requiring hotfixes or rollbacks. A lower change failure rate indicates a more reliable delivery process."
+                    "summary": " This metric measures the percentage of deployments that cause failures in production, requiring hotfixes or rollbacks. A lower change failure rate indicates a more reliable delivery process.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
                 },
                 "recoverytime": {
                     "name": "Failed deployment recovery time",
                     "link": "/guides/dora-metrics-four-keys/",
-                    "summary": "This metric measures the time it takes to recover from a failed deployment. A lower recovery time indicates a more resilient and responsive system."
+                    "summary": "This metric measures the time it takes to recover from a failed deployment. A lower recovery time indicates a more resilient and responsive system.<br><br>Want to assess your team’s software delivery performance? Try our <a href='/quickcheck'>DORA Quick Check</a> for insights on how to improve."
                 }
             }
         },


### PR DESCRIPTION
This PR updates the Core popovers for Software Delivery and each of the four key metrics, adding a link to the quickcheck.

It also applies a subtle border to the "learn more" link to separate it from links in the popover content.

Preview: https://doradotdev-staging--pr685-drafts-on-1mi744e0.web.app/research/

Fixes #682