### PR TITLE
Update survey and research pages to reflect report publication date

### DIFF
--- a/hugo/content/research/2024/_index.md
+++ b/hugo/content/research/2024/_index.md
@@ -19,7 +19,7 @@ Your responses are being analyzed and will provide the basis for this year's DOR
 * **Platform Engineering** - We want to better understand how your organization is approaching platform engineering. Platform engineering may include both technologies and teams. How does platform engineering impact software delivery performance?
 * **Developer Experience** - We want to learn more about your overall experience as you work to deliver for your customers. How does your experience impact the value you're able to deliver?
 
-
+We expect to publish the 2024 DORA report sometime in October, 2024. [Join the DORA community](https://dora.community) to be notified when the report is published, for discussions with the rest of the community, and for future research study participation opportunities.
 <!--
 ### The 2023 Accelerate State of DevOps survey is now closed.
 Thank you to everyone who participated! Your responses informed the [Accelerate State of DevOps 2023 Report](/dora-report-2023).

--- a/hugo/content/survey/_index.md
+++ b/hugo/content/survey/_index.md
@@ -15,6 +15,7 @@ Your responses are being analyzed and will provide the basis for this year's DOR
 * **Platform Engineering** - We want to better understand how your organization is approaching platform engineering. Platform engineering may include both technologies and teams. How does platform engineering impact software delivery performance?
 * **Developer Experience** - We want to learn more about your overall experience as you work to deliver for your customers. How does your experience impact the value you're able to deliver?
 
+We expect to publish the 2024 DORA report sometime in October, 2024. [Join the DORA community](https://dora.community) to be notified when the report is published, for discussions with the rest of the community, and for future research study participation opportunities.
 
 <!--
 ### The 2023 Accelerate State of DevOps survey is now closed.


### PR DESCRIPTION
This commit updates the 2024 DORA survey and research pages to reflect that the report is expected to be published in October 2024.

The change ensures that users are informed about the expected publication date and can join the DORA community to stay updated.

Preview:
* [2024 research](https://doradotdev-staging--pr688-drafts-off-utvfbym1.web.app/research/2024/)
* [survey](https://doradotdev-staging--pr688-drafts-off-utvfbym1.web.app/survey)