### PR TITLE
Remove the callout about the Quick Check

### DIFF
--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -6,62 +6,61 @@ bannerTitle: "Get Better at Getting Better"
 bannerSubtitle: "DORA is the largest and longest running research program of its kind, that seeks to understand the capabilities that drive software delivery and operations performance. DORA helps teams apply those capabilities, leading to better organizational performance."
 ---
 
-{{< article columns="2" 
-    title="The Accelerate State of DevOps Report 2023" 
+{{< article columns="2"
+    title="The Accelerate State of DevOps Report 2023"
     url="https://cloud.google.com/devops/state-of-devops"
     cta="Read the Report"
-    img-src="/research/2023/dora-report/2023-dora-accelerate-state-of-devops-report.png"  
-    img-alt="The Accelerate State of DevOps Report 2023" 
+    img-src="/research/2023/dora-report/2023-dora-accelerate-state-of-devops-report.png"
+    img-alt="The Accelerate State of DevOps Report 2023"
     img-align="right"
     img-stroke="true"
     text-size-ratio="1.15"
     >}}
-For the last nine years, we've produced the State of DevOps report, hearing from over 36,000 professionals worldwide. 
+For the last nine years, we've produced the State of DevOps report, hearing from over 36,000 professionals worldwide.
 
 We've outlined the DevOps practices that drive successful software delivery and operational performance, with a deep focus on user-centric design in the 2023 report.
 
 Use these findings to accelerate organizational performance while reducing burnout.
 {{< /article >}}
 
-{{< article 
-    columns="2" 
-    title="DevOps Dozen Winner" 
+{{< article
+    columns="2"
+    title="DevOps Dozen Winner"
     url="https://devopsdozen.com/"
     img-src="/resources/img/best-devops-research.png"
-    img-align="left" 
+    img-align="left"
     delete_on="2024-03-01" >}}
-DORA's Accelerate State of DevOps Report was selected for *Best DevOps Survey/Analysis/Research*, which recognizes "research that has significantly and positively impacted the DevOps community." 
+DORA's Accelerate State of DevOps Report was selected for *Best DevOps Survey/Analysis/Research*, which recognizes "research that has significantly and positively impacted the DevOps community."
 
 Congratulations to all of the [2024 DevOps Dozen winners](https://devopsdozen.com/)!
 {{< /article >}}
 
-{{< article columns="1" 
-    title="DORA Quick Check" 
+{{< article columns="1"
+    title="DORA Quick Check"
     url="/quickcheck/"
-    cta="Take the Quick Check" 
-    img-src="/img/quickcheck/hero_illustration.svg" 
-    img-align="left" 
+    cta="Take the Quick Check"
+    img-src="/img/quickcheck/hero_illustration.svg"
+    img-align="left"
     >}}
-**Updated with 2023 findings**
 
 Use our quick check tool to discover how you compare to industry peers, identify specific capabilities you can use to improve performance, and make progress on your software delivery goals.
 {{< /article >}}
 
-{{< article columns="1" 
-    title="Generative AI" 
+{{< article columns="1"
+    title="Generative AI"
     url="/guides/how-to-innovate-with-generative-ai/"
-    cta="Read the guide" 
-    img-src="/guides/how-to-innovate-with-generative-ai/how-to-innovate-with-ai.png" 
-    img-align="left" 
+    cta="Read the guide"
+    img-src="/guides/how-to-innovate-with-generative-ai/how-to-innovate-with-ai.png"
+    img-align="left"
     >}}
 Leverage DORA's research findings to apply a holistic, iterative strategy as you experiment with and adopt emerging AI technologies. Learn how a focus on users can help ensure positive outcomes.
 {{< /article >}}
 
-{{< article 
-    columns="1" 
-    title="2024 DORA Awards" 
+{{< article
+    columns="1"
+    title="2024 DORA Awards"
     cta="Submit your story now"
-    url="https://docs.google.com/forms/d/e/1FAIpQLSfqR-4fS9MlqjhgYmdDcrGqEkGccA_8MJoRXevYO1xJoXSkTA/viewform" 
+    url="https://docs.google.com/forms/d/e/1FAIpQLSfqR-4fS9MlqjhgYmdDcrGqEkGccA_8MJoRXevYO1xJoXSkTA/viewform"
     img-src="/img/features/dora-awards-2024.png"
     img-align="left"
     img-stroke="false"
@@ -69,12 +68,12 @@ Leverage DORA's research findings to apply a holistic, iterative strategy as you
 The Google Cloud DORA Awards applications are now open! Featuring 10 different categories including DevOps, AI innovation, and more, the awards celebrate Google Cloud customers putting DORA insights into practice.
 {{< /article >}}
 
-{{< article columns="1" 
-    title="DORA Core" 
+{{< article columns="1"
+    title="DORA Core"
     url="/research/"
-    cta="Explore the model" 
-    img-src="/img/features/homepage-core-snipe.png" 
-    img-align="left" 
+    cta="Explore the model"
+    img-src="/img/features/homepage-core-snipe.png"
+    img-align="left"
     >}}
 DORA Core represents the most well-established findings across the history and breadth our research program. Use it to guide transformation efforts in your organization.
 {{< /article >}}


### PR DESCRIPTION
Yes, it's updated with 2023 data but it's now July of 2024

Let's not shout about it being updated with 2023 data anymore