### PR TITLE
Link the ROI report under `/publications` to the ROI landing page.

### DIFF
--- a/hugo/content/publications/_index.md
+++ b/hugo/content/publications/_index.md
@@ -6,7 +6,7 @@ bannerTitle: "Publications by DORA"
 bannerSubtitle: "Findings from DORA's research program are made available through a series of publications, including the Accelerate State of DevOps Report."
 ---
 > Interested in being a sponsor of one of our upcoming Accelerate State of DevOps Reports?
-> 
+>
 > Please reach out to sponsor-dora@google.com for more information on the sponsorship opportunities!
 
 ## 2023 Accelerate State of DevOps Report
@@ -64,9 +64,9 @@ bannerSubtitle: "Findings from DORA's research program are made available throug
 ## Additional Publications
 <!-- add publications as list items, using markdown syntax (list items are designated with a leading dash) -->
 
-- [![ROI of DevOps Whitepaper](img/whitepaper-roi.png)](https://bit.ly/roi-of-devops)
-  **[The ROI of DevOps Transformation](https://bit.ly/roi-of-devops)**
-  [Get the Whitepaper](https://bit.ly/roi-of-devops)
+- [![ROI of DevOps Whitepaper](img/whitepaper-roi.png)](/research/2020/)
+  **[The ROI of DevOps Transformation](/research/2020/)**
+  [Download the Whitepaper](/research/2020/)
 - [![DevOps Awards Winners 2021](img/devops_awards_fullebook.png)](https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf)
   **[DevOps Awards Winners 2021](https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf)**
   [Read the ebook](https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf)

--- a/test/playwright/tests/publications/index.spec.ts
+++ b/test/playwright/tests/publications/index.spec.ts
@@ -21,12 +21,10 @@ test('Publications page loads correctly', async ({ page }) => {
   await expect(currentReportPage).toHaveURL('https://cloud.google.com/devops/state-of-devops');
 
   // Check the ROI Report
-  const [roiReportPage] = await Promise.all([
-    page.waitForEvent('popup'),
-    page.getByRole('link', { name: 'Get the Whitepaper' }).click(),
-  ]);
-
-  await expect(roiReportPage).toHaveURL('https://cloud.google.com/resources/roi-of-devops-transformation-whitepaper');
+  expect(page.getByRole('link', { name: 'Download the Whitepaper' })).toHaveAttribute(
+    'href',
+    '/research/2020/'
+  )
 
   // Test the "Read the ebook" link
   const ebookLink = page.getByRole('link', { name: 'Read the ebook' });


### PR DESCRIPTION
* Update the test for the publications landing page
* Link the ROI Report to the landing page

Preview:  https://doradotdev-staging--pr701-drafts-on-2v5jh3xr.web.app/publications/

Fixes #700 