### PR TITLE
Refactor playwright tests for `/search/`

### DIFF
--- a/test/playwright/tests/search/search-page.spec.ts
+++ b/test/playwright/tests/search/search-page.spec.ts
@@ -1,10 +1,17 @@
 import { test, expect } from '@playwright/test';
 
-test('Perform a search for "generative"', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
     await page.goto('/search/');
     await page.getByRole('searchbox', { name: 'Search dora.dev for...' }).fill('generative');
     await page.getByRole('button', { name: 'search' }).click();
+});
+
+test('A search for "generative" finds results.', async ({ page }) => {
     await expect(page.locator('#webResultsContainer')).toContainText('Generative Organizational Culture');
     await expect(page.locator('#publicationResults')).toContainText('Read the full report');
-    await expect(page.locator('[href*="ask.dora.dev"]')).toBeVisible();
 });
+
+test('A search for "generative" includes a link to ask.dora.dev in the "Explore further" section.', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Explore further Try DORA’s' })).toBeVisible();
+});
+


### PR DESCRIPTION
ask.dora.dev sometimes appears in the search results. This adds and explicit test for it in the sidebar.

Also refactors to match our emerging playwright conventions.