### PR TITLE
remove firebase config

### DIFF
--- a/ci/firebase-config.doradotdev-staging.js
+++ b/ci/firebase-config.doradotdev-staging.js
@@ -1,9 +1,0 @@
-export const config = {
-    apiKey: "AIzaSyATzQBPDMDXsXdqzJLcQ5msW0qrrz-YP_Q",
-    authDomain: "doradotdev-staging.firebaseapp.com",
-    projectId: "doradotdev-staging",
-    storageBucket: "doradotdev-staging.appspot.com",
-    messagingSenderId: "280168604467",
-    appId: "1:280168604467:web:4cb9a9d802c56290e1d446",
-    measurementId: "G-F38S41VXVN"
-};

--- a/ci/firebase-config.doradotdev.js
+++ b/ci/firebase-config.doradotdev.js
@@ -1,9 +1,0 @@
-export const config = {
-    apiKey: "AIzaSyB8xakcxSGv6Gms7u-Kk21r20h4zRySqh4",
-    authDomain: "doradotdev.firebaseapp.com",
-    projectId: "doradotdev",
-    storageBucket: "doradotdev.appspot.com",
-    messagingSenderId: "712907887884",
-    appId: "1:712907887884:web:a424bce80cf0eabcf56529",
-    measurementId: "G-HWLXSJLRVQ"
-};

--- a/ci/preview-content.cloudbuild.yaml
+++ b/ci/preview-content.cloudbuild.yaml
@@ -1,9 +1,4 @@
 steps:
-  - id: 'Stage FirebaseConfig'
-    name: 'bash'
-    script: |
-      # Copy correct Firestore config per project
-      cp -v ci/firebase-config.${PROJECT_ID}.js /workspace/hugo/static/js/firebase-config.js
 
   - id: 'Svelte / Hugo Build'
     name: 'node'

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,55 +9,19 @@ To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (r
 ## CI/CD
 See `/ci/README.md`
 
-
-## Firebase Platform Advanced Development
-### Firebase Platform Development and Administration
-All development and deployment/administration for *Platform capabilities* include such items as the following:
- - Firebase Hosting
- - Firebase Cloud Functions Development and Deployment
- - Firebase Extension Deployment
- - Firestore Data retention and Firestore Rules Deployment
-
 ## Hosting
-The production site (and pre-prod environments) are hosted in Firebase. Some hosting features (e.g. redirects and contact form submissions) are provided by Firebase, and will not be available when the site is served locally by Hugo alone.
+The production site (and pre-prod environments) are hosted in Firebase. Some hosting features (most notably, redirects) are provided by Firebase, and will not be available when the site is served locally by Hugo alone.
 
 ### **Firebase Emulation**
 Many Firebase features may be run locally through the Firebase emulator.  This requires two terminal windows and some knowledge about specific Firebase options desired to test.
 
 #### **Firestore and Hosting**
-To emulate Firestore and Firebase hosting (to see features like server-side redirects), and user form collection
+To emulate Firestore and Firebase hosting (to see features like server-side redirects)
   - in terminal 1, run `watch -n 2 hugo -s hugo -e development`
     - _this will continuously rebuild the site and save it to `/public` (which is the firebase hosting serving root)_
-  - in terminal 2, run `firebase emulators:start --only firestore,hosting`
+  - in terminal 2, run `firebase emulators:start --only hosting`
   - access the site at `http://localhost:5000`
     - _in this configuration, the browser will not auto-reload when source files are changed_
-
-#### **Cloud Functions**
-To emulate Firestore Cloud Functions, you will need NodeJS installed locally. For version requirements review `functions/{function_name}/package.json` and may start the Functions Emulator (with hosting and firestore) with the following: `firebase emulators:start --only firestore,hosting,functions`.
-
-Cloud Function Configuration: The hosted version of the Cloud Function environment variables to get the value for the "Send To" value and expiration time.  You may pass in a local environment option by setting the `MONITOR_SEND_TO` and `INQUIRY_EXPIRES_DAYS` values within a newly created file `functions/{function_name}/.env.local`. (NOTE: By design, all `*.env.local` files are excluded from Git a defined in the `.gitignore`)
-
-#### **Extensions**
-Firebase emulation for extensions is available by adjusting the CLI option (i.e., either with the `--only extensions` or loading all by eliminating the `--only` completely).  However, by (current) [Firebase design](https://github.com/firebase/firebase-tools/issues/5510), _extensions require access to the hosted Firebase project at startup_ as defined within `./.firebaserc`.  This is used for start-up authentication only; If you not have access, this can cause permissions errors and fail to start the emulation (see notes below).
-
-For local development extension configuration, you may be set certain Extension variables by adding them in the following file: `extensions/${EXTENSION_NAME}.env.local` (e.g., `extensions/firestore-send-email.env.local`).  More specifically, for the Fire Store Send Email extension, you will two files:
- - `firestore-send-email.env.local` - You can copy keys from the src `firestore-send-email.env.doradotdev`
- - `firestore-send-email.secret.local` - is a special file used for local development that contains only one entry:
- `SMTP_PASSWORD=my_smtp_password_in_clear_text`
- This file and value will be used for the local Firebase emulator as a substitute for the Secret Manager reference.
-
-In a hosted environment:
-1) The Deployer account `${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com` will require the _added_ role of `Secret Manager Viewer`
-2) The Billing API needs to be enabled.
-
-      **_Be sure to not check this file into Git!_**
-
-*Extension Notes*
-1) If you get a permissions error on deployment (ie., when using the `extensions` option):
-    - Hijack the `./.firebaserc` (via `git update-index --assume-unchanged .firebaserc`) and make changes in the Firebase instance configuration.  Just know that doing this will not commit changed back to source control.
-
-2) To write to the Firestore database, if you change Firebase Projects, either through configuration (e.g., `./.firebaserc`) or command-line argument (`--project `), you may need to modify the Firestore Config object defined in `hugo/static/js/firebase-config.js` to align with the new project configurations.  Otherwise, you will not see Firestore updates.  WARNING: Be sure you _do not_ unintentionally check this change into source control tracking.
-
 
 ## Bugs
 When deploying Cloud Functions with Cloud Build, you can encounter the following error:


### PR DESCRIPTION
This PR strips out Firebase config files and CI infra that is no longer necessary, since we've replaced the Firebase-powered contact form.

Fixes #746
Fixes #747
Fixes #748