### PR TITLE
Fix broken image on the home page

### DIFF
--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -50,7 +50,7 @@ Use our quick check tool to discover how you compare to industry peers, identify
     title="AI in the Workplace"
     url="/research/2024/ai-preview/"
     cta="Read the preview"
-    img-src="research/2024/ai-preview/dora-report-ai-preview-hero.png"
+    img-src="/research/2024/dora-report-ai-preview-hero.png"
     img-align="left"
     >}}
 AI has dominated the tech landscape in recent years. But how has this powerful technology infiltrated the everyday lives of developers? Read an early preview into some findings about AI in the workplace.

--- a/test/playwright/tests/homepage.spec.ts
+++ b/test/playwright/tests/homepage.spec.ts
@@ -2,7 +2,34 @@ import { test, expect } from '@playwright/test';
 
 // baseURL default is defined in playwright.config.ts
 
+export const heroImages = [
+  '/research/2023/dora-report/2023-dora-accelerate-state-of-devops-report.png',
+  '/img/quickcheck/hero_illustration.svg',
+  '/research/2024/dora-report-ai-preview-hero.png',
+  '/guides/how-to-innovate-with-generative-ai/how-to-innovate-with-ai.png',
+  '/img/features/homepage-core-snipe.png'
+];
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
 test('test', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByText('Get Better at Getting Better')).toBeVisible();
 });
+
+test('Homepage has the correct title.', async ({ page }) => {
+  await expect(page).toHaveTitle('DORA | Get Better at Getting Better');
+});
+
+test('Homepage has the correct header.', async ({ page }) => {
+  await expect(page.locator('h1')).toContainText('Get Better at Getting Better');
+});
+
+heroImages.forEach((heroImage) => {
+  const imageName = heroImage.substring(heroImage.lastIndexOf('/') + 1, heroImage.lastIndexOf('.'));
+  test(`Homepage hero image ${imageName} is visible`, async ({ page }) => {
+    await expect(page.locator(`img[src="${heroImage}"]`)).toBeVisible();
+  });
+})


### PR DESCRIPTION
The AI Preview image is giving a 404.

This fixes the path and adds additional tests for the home page.

This bug was introduced in 9b006fda123563d6625151866bc654f25d21f43a.

Fixes #762 

Preview - https://doradotdev--pr761-drafts-off-gywayge1.web.app/