### PR TITLE
2024 survey questions

### DIFF
--- a/hugo/content/research/2024/questions.md
+++ b/hugo/content/research/2024/questions.md
@@ -1,0 +1,13 @@
+---
+title: "DORA Research Questions"
+date: 2024-10-01
+research_year: "2024"
+draft: false
+tab_order: "10"
+tab_title: "Questions"
+type: "research_archives/preview"
+---
+
+## Coming soon!
+
+The questions used in the 2024 DORA survey will be published here shortly after the 2024 report is released. In the meantime, you might like to review the [questions used in 2023](/research/2023/questions) or start a [conversation with your team](https://conversations.dora.dev).

--- a/hugo/layouts/research_archives/questions/single.html
+++ b/hugo/layouts/research_archives/questions/single.html
@@ -9,7 +9,7 @@
 <section class="hasSidebar">
     <article id="questions">
         <h2>Survey Questions</h2>
-        <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ .Params.research_year }}/dora-report/">{{ .Params.research_year }} Accelerate State of DevOps Report</a></h4>
+        <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ .Params.research_year }}/dora-report/">{{ .Params.research_year }} Accelerate State of DevOps Report</a>.</h4>
         {{ with index .Site.Data.survey_questions .Params.research_year }}
             {{  range sort .categories "heading" }}
                 <h3 id="{{ .heading | anchorize }}">{{ .heading }}</h3>
@@ -47,7 +47,7 @@
                 {{ end }}
             {{ end }}
         {{ end }}
-        </article> 
+        </article>
     <sidebar>
         {{ partial "research_sidebar.html" . }}
     </sidebar>

--- a/test/playwright/tests/research/2024/2024-questions.spec.ts
+++ b/test/playwright/tests/research/2024/2024-questions.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { sidebarLinks } from '../sidebarLinks';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/research/2024/questions');
+});
+
+test('2024 survey questions page has the correct title.', async ({ page }) => {
+  await expect(page).toHaveTitle('DORA | DORA Research Questions');
+});
+
+test('2024 survey questions page has the correct header.', async ({ page }) => {
+  await expect(page.locator('h2')).toContainText('Coming soon!');
+});
+
+test('2024 survey questions page has the correct sidebar.', async ({ page }) => {
+  for (const sidebarLink of sidebarLinks) {
+    await expect(page.getByRole('link', { name: sidebarLink, exact: true })).toBeVisible();
+  }
+});


### PR DESCRIPTION
* Adds placeholder for 2024 questions.
* Adds a `.` at the end of the sentence
* Removes some trailing whitespace

Preview links:

* https://doradotdev--pr776-drafts-off-ueevmz8m.web.app/research/2024/questions/
* https://doradotdev--pr776-drafts-off-ueevmz8m.web.app/research/2023/questions/ (look for the `.`)

