### PR TITLE
Prep the 2024 errata page

### DIFF
--- a/hugo/content/research/2024/errata.md
+++ b/hugo/content/research/2024/errata.md
@@ -1,0 +1,20 @@
+---
+title: "DORA Research Errata"
+date: 2024-10-07
+updated: 2024-10-08
+research_year: "2024"
+draft: true
+tab_order: "15"
+tab_title: "Errata"
+type: "research_archives"
+---
+
+This page lists errors and corrections to the 2024 Accelerate State of DevOps Report. To track revisions, report PDFs are stamped with a version number. The initial version of the 2024 report is `v.2024-10`.
+
+
+-----
+<div style="text-align:center; margin-top:2em;">
+Have you found an error the 2024 Accelerate State of DevOps Report?
+
+<a href='mailto:dora-advocacy@google.com?subject=DORA+Accelerate+State+of+DevOps+Report+2024+error+report' class='button' target="_blank">Submit a change or correction</a>
+</div>


### PR DESCRIPTION
Currently in `draft`

Need to verify the version in the final report.

Preview: https://doradotdev--pr781-drafts-on-2y04av8j.web.app/research/2024/errata

With drafts off, a 404 is expected at https://doradotdev--pr781-drafts-off-burwjgey.web.app/research/2024/errata

Supports: #689 