### PR TITLE
Fix typo in redirects to be tested

### DIFF
--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -53,4 +53,4 @@
 /research/2017-and-earlier/2017-state-of-devops-report.pdf,/research/2017/2017-state-of-devops-report.pdf,301
 /capabilities/loosely-coupled-architecture/,/capabilities/loosely-coupled-teams/,301
 /sponsors/dora-brand-guidelines/,/brand-guidelines/,301
-/dora-brand-guidelines/,/brand-guidelines/,,301
+/dora-brand-guidelines/,/brand-guidelines/,301


### PR DESCRIPTION
No functionality changes, just removes an extra `,` from `redirects.csv`