### PR TITLE
Removing /resources from State of DevOps report link as well as fixing hugo build issues

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -151,7 +151,7 @@
                 },
                 {
                     "source": "/report",
-                    "destination": "https://cloud.google.com/resources/devops/state-of-devops",
+                    "destination": "https://cloud.google.com/devops/state-of-devops",
                     "type": 302
                 },
                 {

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -8,7 +8,7 @@ bannerSubtitle: "DORA is the largest and longest running research program of its
 
 {{< article columns="2"
     title="Accelerate State of DevOps Report 2024"
-    url="https://cloud.google.com/resources/devops/state-of-devops"
+    url="https://cloud.google.com/devops/state-of-devops"
     cta="Read the Report"
     img-src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png"
     img-alt="The Accelerate State of DevOps Report 2024"

--- a/hugo/content/guides/how-to-innovate-with-generative-ai/index.md
+++ b/hugo/content/guides/how-to-innovate-with-generative-ai/index.md
@@ -1,7 +1,7 @@
 ---
 title: "How to enable your software delivery teams to innovate with generative AI"
 titleForHTMLHead: "How to enable your software delivery teams to innovate with generative AI"
-date: 2024-06-122024-06-12
+date: 2024-06-12
 updated: 2024-08-16
 authors:
     1: {name: 'Amanda Lewis', url: 'https://linkedin.com/in/lewisamanda'}

--- a/hugo/content/publications/_index.md
+++ b/hugo/content/publications/_index.md
@@ -13,7 +13,7 @@ bannerSubtitle: "Findings from DORA's research program are made available throug
 
 <section class="publicationHighlight">
     <aside>
-        <a href="https://cloud.google.com/resources/devops/state-of-devops" target="_blank"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 Accelerate State of DevOps Report"></a>
+        <a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 Accelerate State of DevOps Report"></a>
     </aside>
     <article>
        <p>
@@ -23,7 +23,7 @@ bannerSubtitle: "Findings from DORA's research program are made available throug
          This report highlights the significant impact of AI on software development, explores platform engineering's promises and challenges, and emphasizes user-centricity and stable priorities for organizational success.
        </p>
         <p>Findings from our research can help inform your team's continuous improvement journey.</p>
-       <a href="https://cloud.google.com/resources/devops/state-of-devops" target="_blank"><button class="secondary">Download the report</button></a>
+       <a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><button class="secondary">Download the report</button></a>
     </article>
 </section>
 

--- a/hugo/content/quickcheck/2019/results.html
+++ b/hugo/content/quickcheck/2019/results.html
@@ -24,7 +24,7 @@ type: quickcheck_2019
     x-on:click.outside="isModalOpen = false"
     x-on:keydown.escape.window="isModalOpen = false"
     x-on:keydown.enter.window="isModalOpen = false">
-    <h3>You're performing better than <span id="percentile">&nbsp;&nbsp;&nbsp;</span>&percnt; of 2019 <a href="https://cloud.google.com/resources/devops/state-of-devops/" target="_blank">State&nbsp;of&nbsp;DevOps&nbsp;Survey</a> respondents.&nbsp;</h3>
+    <h3>You're performing better than <span id="percentile">&nbsp;&nbsp;&nbsp;</span>&percnt; of 2019 <a href="https://cloud.google.com/devops/state-of-devops/" target="_blank">State&nbsp;of&nbsp;DevOps&nbsp;Survey</a> respondents.&nbsp;</h3>
     <small>Take the Quick Check from other research years: <a href="/quickcheck/2023/">2023</a>&nbsp;&nbsp;<a href="/quickcheck/2022/">2022</a>&nbsp;&nbsp;<a href="/quickcheck/2021/">2021</a>&nbsp;&nbsp;<a href="/quickcheck/2019/">2019</a></small>
     <br><br>
     <button x-on:click="isModalOpen = true" aria-controls="share-modal">Share results</button>
@@ -166,7 +166,7 @@ type: quickcheck_2019
             <div>
                 <h2>How your performance compares</h2>
                 <p>Based on your <a href='{{% relref "/quickcheck/" %}}'>quick check</a> answers, see how you compare to the
-                <a href="https://cloud.google.com/resources/devops/state-of-devops/">2019 Accelerate State of DevOps</a> respondents overall, and to people within the same industry as you.</p>
+                <a href="https://cloud.google.com/devops/state-of-devops/">2019 Accelerate State of DevOps</a> respondents overall, and to people within the same industry as you.</p>
             </div>
             <div id="perf-comparison">
                 <div>
@@ -221,7 +221,7 @@ type: quickcheck_2019
             <p >Based on your performance, you are classified as a <strong class="color-by-profile"><span class="profile-title">unknown</span> performer</strong>. Here is how the performance profiles compare. Note
                 that your answers to the five questions asked in Step 1 of the quick check may not match the
                 descriptions in the table below. The performance profiles in this table are based on statistical
-                analysis of the aggregated responses to the 2019 Accelerate State of DevOps survey. For more on this analysis, read the &ldquo;Methodology&rdquo; section of the <a href="https://cloud.google.com/resources/devops/state-of-devops/">Accelerate State of DevOps Report</a>.</p>
+                analysis of the aggregated responses to the 2019 Accelerate State of DevOps survey. For more on this analysis, read the &ldquo;Methodology&rdquo; section of the <a href="https://cloud.google.com/devops/state-of-devops/">Accelerate State of DevOps Report</a>.</p>
             </div>
             <table class="comparison-table">
                 <thead>

--- a/hugo/content/research/2023/structural-equation-models/index.md
+++ b/hugo/content/research/2023/structural-equation-models/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DORA Research Structural Equation Models 2023"
-date: structural-equation-model-01-01
+date: 2023-01-01
 research_year: "2023"
 draft: false
 tab_order: "3"

--- a/hugo/content/research/2024/dora-report/index.md
+++ b/hugo/content/research/2024/dora-report/index.md
@@ -14,7 +14,7 @@ hideSiteBanner: true
 <grid class="border_none" style="margin-top:1rem;">
 <item>
 
-<a href="https://cloud.google.com/resources/devops/state-of-devops" target="_blank"><img src="2024-dora-accelerate-state-of-devops-report.png" style="max-width:24em;"></a>
+<a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><img src="2024-dora-accelerate-state-of-devops-report.png" style="max-width:24em;"></a>
 
 </item>
 
@@ -26,7 +26,7 @@ DORA has been investigating the capabilities, practices, and measures of high-pe
 This report highlights the significant impact of AI on software development, explores platform engineering’s promises and challenges, and emphasizes user-centricity and stable priorities for organizational success.
 </p>
 <p>
-<a href="https://cloud.google.com/resources/devops/state-of-devops" target="_blank"><button class="secondary">Download the report</button></a>
+<a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><button class="secondary">Download the report</button></a>
 </p>
 </grid>
 

--- a/hugo/layouts/partials/quickcheck/percentile_graph.html
+++ b/hugo/layouts/partials/quickcheck/percentile_graph.html
@@ -37,6 +37,6 @@
             </div>
         </div>
     </div>
-    <h3 class="better-than">You're performing better than <span id="percentile">&nbsp;&nbsp;&nbsp;</span>&percnt; of {{ .Date.Year }} <a href="https://cloud.google.com/resources/devops/state-of-devops/" target="_blank">Accelerate State&nbsp;of&nbsp;DevOps&nbsp;</a> survey respondents.&nbsp;</h3>
+    <h3 class="better-than">You're performing better than <span id="percentile">&nbsp;&nbsp;&nbsp;</span>&percnt; of {{ .Date.Year }} <a href="https://cloud.google.com/devops/state-of-devops/" target="_blank">Accelerate State&nbsp;of&nbsp;DevOps&nbsp;</a> survey respondents.&nbsp;</h3>
     <small>Take the Quick Check from other research years: <a href="/quickcheck/2023/">2023</a>&nbsp;&nbsp;<a href="/quickcheck/2022/">2022</a>&nbsp;&nbsp;<a href="/quickcheck/2021/">2021</a>&nbsp;&nbsp;<a href="/quickcheck/2019/">2019</a></small>
 </section>

--- a/hugo/layouts/partials/quickcheck/performance_comparison.html
+++ b/hugo/layouts/partials/quickcheck/performance_comparison.html
@@ -2,7 +2,7 @@
     <div>
         <h2>How your performance compares</h2>
         <p>Based on your <a href='{{ "/quickcheck/" | relURL }}'>quick check</a> answers, see how you compare to the
-        <a href="https://cloud.google.com/resources/devops/state-of-devops/">2022 Accelerate State of DevOps</a> respondents overall, and to people within the same industry as you.</p>
+        <a href="https://cloud.google.com/devops/state-of-devops/">2022 Accelerate State of DevOps</a> respondents overall, and to people within the same industry as you.</p>
     </div>
     <div id="perf-comparison">
         {{- partial "tab_navigation.v2" (dict

--- a/hugo/themes/dora/layouts/partials/site_banner.html
+++ b/hugo/themes/dora/layouts/partials/site_banner.html
@@ -1,3 +1,3 @@
 <div class="site-banner">
-    Theme Default Site Banner <a href="https://cloud.google.com/resources/devops/state-of-devops" target="_blank">Download the 2023 DORA Report</a>
+    Theme Default Site Banner <a href="https://cloud.google.com/devops/state-of-devops" target="_blank">Download the 2023 DORA Report</a>
 </div>

--- a/test/playwright/tests/publications/index.spec.ts
+++ b/test/playwright/tests/publications/index.spec.ts
@@ -32,7 +32,7 @@ test('Publications page links to the DORA awards ebook.', async ({ page }) => {
 
 // Mapping for "Download the report" links which, by convention, got to /research/:year or /research/:year/dora-report
 const downloadTheReportMap = [
-  { year: 2024, url: 'https://cloud.google.com/resources/devops/state-of-devops' },
+  { year: 2024, url: 'https://cloud.google.com/devops/state-of-devops' },
   { year: 2023, url: '/research/2023/dora-report/' },
   { year: 2022, url: '/research/2022/dora-report/' },
   { year: 2021, url: '/research/2021/dora-report/' },

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -10,7 +10,7 @@
 /concepts/wellbeing,/capabilities/well-being/,302
 /capabilities/wellbeing,/capabilities/well-being/,302
 /dora-report,/report,302
-/report,https://cloud.google.com/resources/devops/state-of-devops,302
+/report,https://cloud.google.com/devops/state-of-devops,302
 /report/roi,/research/2020,302
 /roi-report,/research/2020,302
 /dora-report-roi/,/research/2020,302


### PR DESCRIPTION
Fixes #801 and fixes #821 

Previous links to the latest 2024 DORA report pointed to `https://cloud.google.com/resources/devops/state-of-devops`. This PR removes the `/resources` from the URL.

Additionally, build errors were present when running `hugo` command. Changes to the dates within two index.md files addresses these errors.