### PR TITLE
Add support for printed version check

### DIFF
--- a/hugo/content/vc/_index.md
+++ b/hugo/content/vc/_index.md
@@ -20,6 +20,9 @@ bannerSubtitle: "Check if you have the most recent version of the DORA Report."
   <p>The following versions of the DORA Report are available via this version checker:</p>
   <ul>
     <li>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2024.3.p">2024 DORA Report (Printed Version) <code>v. 2024.3.p</code></a>
+    </li>
+    <li>
       <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2024.3">2024 DORA Report <code>v. 2024.3</code></a>
     </li>
     <li>
@@ -37,11 +40,27 @@ bannerSubtitle: "Check if you have the most recent version of the DORA Report."
   </ul>
 </div>
 
+<!-- version is 2024.3.p -->
+<div class="version-content" data-version="2024.3.p">
+  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2024 DORA Report (Printed Version)</h2>
+  <p>
+    You have the most recent printed version of the 2024 report.
+  </p>
+  <p>
+    Your version: <code>v.2024.3.p</code><br />
+    Latest version: <code>v.2024.3.p</code>
+  </p>
+  <p>
+    <a href="/research/2024/dora-report">Download the latest digital version of the 2024 DORA report</a>.
+  </p>
+  <a href="/research/2024/dora-report"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 DORA Report Cover" style="max-width:18em;"></a>
+</div>
+
 <!-- version is 2024.3 -->
 <div class="version-content" data-version="2024.3">
-  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2024 DORA Report</h2>
+  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2024 DORA Report (Digital Version)</h2>
   <p>
-    You have the most recent version of the 2024 report.
+    You have the most recent digital version of the 2024 report.
   </p>
   <p>
     Your version: <code>v.2024.3</code><br />

--- a/test/playwright/tests/vc/version-check.spec.ts
+++ b/test/playwright/tests/vc/version-check.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const versions = [
   { version: '2024.3', expectedText: '2024 DORA Report' },
+  { version: '2024.3.p', expectedText: '2024 DORA Report (Printed Version)' },
   { version: '2024.2', expectedText: '2024 DORA Report' },
   { version: '2024.1', expectedText: '2024 DORA Report' },
   { version: '2023-12', expectedText: '2023 DORA Report' },


### PR DESCRIPTION
We are printing the report and the printed version will have a new version number: v. 2024.3.p.

This updates the version checker page and related tests to account for this.

Preview URLs:

• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=2024.3.p
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=2024.3
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=2024.2
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=2024.1
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=2023-12
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=2023-10
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=216
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?v=1564-1586
• https://doradotdev--pr844-drafts-off-40cifagj.web.app//vc/?foo=1564&bar=15jdi&v=2024.3
