### PR TITLE
Remove the "(coming soon)" from the 2024 questions

### DIFF
--- a/hugo/content/research/2024/questions.md
+++ b/hugo/content/research/2024/questions.md
@@ -1,7 +1,7 @@
 ---
 title: "DORA Research Questions"
 date: 2024-10-01
-updated: 2024-10-07
+updated: 2025-02-04
 research_collection: "2024"
 draft: false
 tab_order: "4"

--- a/hugo/layouts/research_archives/questions/single.html
+++ b/hugo/layouts/research_archives/questions/single.html
@@ -13,8 +13,6 @@
         <h2>Survey Questions</h2>
         {{ if eq $researchYear "core" }}
           <h4>Responses to the following questions were used in the analysis of the <a href="/research/">DORA Core Model</a>.</h4>
-        {{ else if eq $researchYear "2024" }}
-        <h4>Responses to the following questions were used in the analysis published in the {{ $researchYear }} Accelerate State of DevOps Report (coming soon).</h4>
         {{ else }}
             <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchYear }}/dora-report/">{{ $researchYear }} Accelerate State of DevOps Report</a>.</h4>
         {{ end }}

--- a/test/playwright/tests/research/2024/2024-questions.spec.ts
+++ b/test/playwright/tests/research/2024/2024-questions.spec.ts
@@ -10,7 +10,7 @@ test('2024 survey questions page has the correct title.', async ({ page }) => {
 });
 
 test('2024 questions page lists the correct report.', async ({ page }) => {
-  await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis published in the 2024 Accelerate State of DevOps Report (coming soon).');
+  await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis published in the 2024 Accelerate State of DevOps Report.');
 });
 
 test('2024 survey questions page has the correct sidebar.', async ({ page }) => {


### PR DESCRIPTION
The report was published in October of 2024.

Preview: https://doradotdev--pr871-drafts-off-8u71n48d.web.app/research/2024/questions/

Should say
"Responses to the following questions were used in the analysis published in the [2024 Accelerate State of DevOps Report](https://doradotdev--pr871-drafts-off-8u71n48d.web.app/research/2024/dora-report/)."

Production currently says:
Responses to the following questions were used in the analysis published in the 2024 Accelerate State of DevOps Report (coming soon).