### PR TITLE
Add questions used in the AI adoption research

### DIFF
--- a/hugo/content/research/ai/adopt-gen-ai/index.md
+++ b/hugo/content/research/ai/adopt-gen-ai/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Adopt generative AI"
 date: 2025-01-31
-updated: 2025-01-31T00:00:00Z
+updated: 2025-02-04
 research_collection: "Artificial Intelligence"
 draft: false
 tab_order: "8"
@@ -99,6 +99,9 @@ The strategies we recommend will help ensure that AI is used strategically and r
 <small>The value we're examining is how a specific strategy impacts a team's adoption of AI, measured by their response to the survey question: 'Over the last 3 months, approximately what percentage of your team’s work is supported by AI?' Each curve represents 4000 simulated scenarios, comparing teams that haven't adopted the strategy at all with those that have thoroughly integrated it.
 </small>
 
+### Methodology
+
+This research was conducted via a survey that included [questions about AI adoption](/research/ai/adopt-gen-ai/questions/).
 ### Next steps
 
 * [Download and read the 2024 DORA Report](/research/2024/dora-report/) for additional findings from the research program.

--- a/hugo/content/research/ai/adopt-gen-ai/questions.md
+++ b/hugo/content/research/ai/adopt-gen-ai/questions.md
@@ -1,0 +1,9 @@
+---
+title: "AI adoption research questions"
+date: 2025-02-04
+updated: 2025-02-04
+research_collection: "ai-adoption"
+research_collection_title: "AI adoption"
+draft: false
+type: "research_archives/questions"
+---

--- a/hugo/content/research/core/questions.md
+++ b/hugo/content/research/core/questions.md
@@ -1,8 +1,9 @@
 ---
 title: "DORA Research Questions"
 date: 2024-10-01
-updated: 2024-10-07
+updated: 2025-02-04
 research_collection: "core"
+research_collection_title: "Core"
 draft: false
 tab_order: "10"
 tab_title: "Questions"

--- a/hugo/data/survey_questions/ai-adoption.json
+++ b/hugo/data/survey_questions/ai-adoption.json
@@ -1,0 +1,160 @@
+{
+    "categories": [
+        {
+            "heading": "AI adoption",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has policies that govern the adoption of AI-powered tools and services.",
+                        "My organization has policies that allow employees to clearly understand how and when to use AI tools.",
+                        "My organization provides guidelines regarding how to mitigate security and privacy risks when engaging with AI",
+                        "My organization has proactively established safeguards against security and privacy breaches when utilizing AI.",
+                        "My organization has taken concrete steps to alleviate developers' worries about job displacement as a result of AI adoption.",
+                        "My organization allows employees to take time during their work hours to learn to use AI tools.",
+                        "My organization actively encourages employees to incorporate AI tools into their workflow.",
+                        "My organization provides resources (courses, webinars, etc.) for employees to learn how to best incorporate AI into their workflows.",
+                        "My organization is committed to the professional development of its employees.",
+                        "My organization requires employees to complete trainings that provide no inside or outside value to their job roles.",
+                        "My organization is transparent about how AI is being used.",
+                        "My organization has developed metrics for measuring the impact AI has on employee productivity",
+                        "My organization's leadership has clear goals regarding how it expects AI to impact organizational performance"
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Clear AI policies",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has policies that govern the adoption of AI-powered tools and services."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Policies on when and where to use AI",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has policies that allow employees to clearly understand how and when to use AI tools."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Guidelines to mitigate privacy issues",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization provides guidelines regarding how to mitigate security and privacy risks when engaging with AI"
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Safeguards against sec & privacy breaches",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has proactively established safeguards against security and privacy breaches when utilizing AI."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Alleviate displacement worries",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has taken concrete steps to alleviate developers' worries about job displacement as a result of AI adoption."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Time to learn",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization allows employees to take time during their work hours to learn to use AI tools."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Encourage AI in workflows",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization actively encourages employees to incorporate AI tools into their workflow."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Resources to learn about AI",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization provides resources (courses, webinars, etc.) for employees to learn how to best incorporate AI into their workflows."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Invest in employee development",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization is committed to the professional development of its employees."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Mandatory trainings",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization requires employees to complete trainings that provide no inside or outside value to their job roles."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Transparent about AI plans",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization is transparent about how AI is being used."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "AI adoption goals",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has developed metrics for measuring the impact AI has on employee productivity",
+                        "My organization's leadership has clear goals regarding how it expects AI to impact organizational performance"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/hugo/layouts/research_archives/questions/single.html
+++ b/hugo/layouts/research_archives/questions/single.html
@@ -1,9 +1,14 @@
 {{ define "main" }}
 {{- partial "partials/link_styles" "scss/research.scss" -}}
 
-{{ $researchYear := .Params.research_collection }}
+{{ $researchCollectionTitle := "" }}
+{{ if .Params.research_collection_title }}
+  {{ $researchCollectionTitle = .Params.research_collection_title }}
+{{ else }}
+    {{ $researchCollectionTitle = .Params.research_collection }}
+{{ end }}
 
-<h1>DORA Research: {{ .Params.research_collection }}</h1>
+<h1>DORA Research: {{ $researchCollectionTitle }}</h1>
 {{- partial "research_archives_tabs" . -}}
 
         {{ .Content }}
@@ -11,10 +16,12 @@
 <section class="hasSidebar">
     <article id="questions">
         <h2>Survey Questions</h2>
-        {{ if eq $researchYear "core" }}
-          <h4>Responses to the following questions were used in the analysis of the <a href="/research/">DORA Core Model</a>.</h4>
+        {{ if eq .Params.research_collection "core" }}
+            <h4>Responses to the following questions were used in the analysis of the <a href="/research/">DORA Core Model</a>.</h4>
+        {{ else if eq  .Params.research_collection "ai-adoption" }}
+            <h4>Responses to the following questions were used in the analysis of <a href="/research/ai/adopt-gen-ai">Helping developers adopt generative AI: Four practical strategies for organizations</a>.</h4>
         {{ else }}
-            <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchYear }}/dora-report/">{{ $researchYear }} Accelerate State of DevOps Report</a>.</h4>
+            <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchCollectionTitle }}/dora-report/">{{ $researchCollectionTitle }} Accelerate State of DevOps Report</a>.</h4>
         {{ end }}
         {{ with index .Site.Data.survey_questions .Params.research_collection }}
             {{  range sort .categories "heading" }}

--- a/test/playwright/tests/research/ai/ai-adoption-questions.spec.ts
+++ b/test/playwright/tests/research/ai/ai-adoption-questions.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { sidebarLinks } from '../sidebarLinks';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/research/ai/adopt-gen-ai/questions/');
+});
+
+test.skip('AI adoption survey questions page has the correct title.', async ({ page }) => {
+  await expect(page).toHaveTitle('DORA | AI adoption research questions');
+});
+
+test.skip('AI adoption questions page lists the correct research collection.', async ({ page }) => {
+  await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis of Helping developers adopt generative AI: Four practical strategies for organizations.');
+});
+
+test.skip('AI adoption survey questions page has the correct sidebar.', async ({ page }) => {
+  for (const sidebarLink of sidebarLinks) {
+    await expect(page.getByRole('link', { name: sidebarLink, exact: true })).toBeVisible();
+  }
+});
+
+test.skip('AI adoption survey questions page displays its last updated date', async ({ page }) => {
+  await expect(page.locator('.updated')).toContainText('Last updated: ')
+});

--- a/test/playwright/tests/research/core/core-questions.spec.ts
+++ b/test/playwright/tests/research/core/core-questions.spec.ts
@@ -5,24 +5,24 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/research/core/questions/');
 });
 
-test('core questions page has the correct title.', async ({ page }) => {
+test('Core questions page has the correct title.', async ({ page }) => {
   await expect(page).toHaveTitle('DORA | DORA Research Questions');
 });
 
-test('core questions page has the correct header.', async ({ page }) => {
-  await expect(page.locator('h1')).toContainText('DORA Research: core');
+test('Core questions page has the correct header.', async ({ page }) => {
+  await expect(page.locator('h1')).toContainText('DORA Research: Core');
 });
 
-test('core questions page lists the correct report.', async ({ page }) => {
+test('Core questions page lists the correct report.', async ({ page }) => {
     await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis of the DORA Core Model.');
 });
 
-test('core questions page has the correct sidebar.', async ({ page }) => {
+test('Core questions page has the correct sidebar.', async ({ page }) => {
   for (const sidebarLink of sidebarLinks) {
     await expect(page.getByRole('link', { name: sidebarLink, exact: true })).toBeVisible();
   }
 });
 
-test('core questions page displays its last updated date', async ({ page }) => {
+test('Core questions page displays its last updated date', async ({ page }) => {
   await expect(page.locator('.updated')).toContainText('Last updated: ')
 });


### PR DESCRIPTION
* Add the questions used for researching AI adoption
* Update the AI adoption article to link to the questions
* Changes to the layout of questions (impacts annual research and core questions)
* Adds new frontmatter parameter: `research_collection_title` used by core and AI adoption questions.
* Adds and updates tests

NB: This is a WIP, the questions are currently displayed twice to experiment with two diffrent layouts. One will be selected and this will be updated before this is ready for a production deploy.