### PR TITLE
Add questions used in the AI adoption research

### DIFF
--- a/hugo/content/research/ai/adopt-gen-ai/index.md
+++ b/hugo/content/research/ai/adopt-gen-ai/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Adopt generative AI"
 date: 2025-01-31
-updated: 2025-01-31T00:00:00Z
+updated: 2025-02-04
 research_collection: "Artificial Intelligence"
 draft: false
 tab_order: "8"
@@ -98,6 +98,10 @@ The strategies we recommend will help ensure that AI is used strategically and r
 
 <small>The value we're examining is how a specific strategy impacts a team's adoption of AI, measured by their response to the survey question: 'Over the last 3 months, approximately what percentage of your team’s work is supported by AI?' Each curve represents 4000 simulated scenarios, comparing teams that haven't adopted the strategy at all with those that have thoroughly integrated it.
 </small>
+
+### Methodology
+
+This research was conducted via a survey that included [questions about AI adoption](/research/ai/questions/).
 
 ### Next steps
 

--- a/hugo/content/research/ai/adopt-gen-ai/index.md
+++ b/hugo/content/research/ai/adopt-gen-ai/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Adopt generative AI"
 date: 2025-01-31
-updated: 2025-02-04
+updated: 2025-02-05
 research_collection: "Artificial Intelligence"
 draft: false
 tab_order: "8"
@@ -94,14 +94,16 @@ The strategies we recommend will help ensure that AI is used strategically and r
 
 <object data="policy_impact.svg" id="policy_impact" type="image/svg+xml" class="responsive-svg"></object>
 
-<small>This image displays Bayesian posterior distributions, which represent our updated understanding of a value after considering new evidence. The height of each curve over a value indicates the relative plausibility of that value. Taller, narrower curves mean we're more certain about our estimates, while shorter, broader curves reflect greater uncertainty.</small>
-
-<small>The value we're examining is how a specific strategy impacts a team's adoption of AI, measured by their response to the survey question: 'Over the last 3 months, approximately what percentage of your team’s work is supported by AI?' Each curve represents 4000 simulated scenarios, comparing teams that haven't adopted the strategy at all with those that have thoroughly integrated it.
+<p style="padding-left:15em;">
+<small>
+This graph displays Bayesian posterior distributions, which represent our updated understanding of a value after considering new evidence. The height of each curve over a value indicates the relative plausibility of that value. Taller, narrower curves mean we're more certain about our estimates, while shorter, broader curves reflect greater uncertainty.
 </small>
-
-### Methodology
-
-This research was conducted via a survey that included [questions about AI adoption](/research/ai/questions/).
+</p>
+<p style="padding-left:15em;">
+<small>
+The value we're examining is how a specific strategy impacts a team's adoption of AI, measured by their response to the survey question: 'Over the last 3 months, approximately what percentage of your team’s work is supported by AI?' Each curve represents 4000 simulated scenarios, comparing teams that haven't adopted the strategy at all with those that have thoroughly integrated it.
+</small>
+</p>
 
 ### Next steps
 
@@ -109,3 +111,15 @@ This research was conducted via a survey that included [questions about AI adopt
 * [Read more about how to transform your organization](/guides/devops-culture-transform/) for perspective into the importance of ensuring teams have the tools and resources to do their job, and of making good use of their skills and abilities.
 * Read about strategies the DORA team has identified for [ensuring AI amplifies developer value](/research/ai/value-of-development-work/). This article provides further guidance for  ensuring job satisfaction and productivity among developers.
 * [Join the dora.community](https://dora.community) to share your approaches and learn about how other organizations are encouraging their developers to adopt AI.
+
+### Notes on method
+
+This research was conducted via a survey that included [questions about AI adoption](/research/ai/questions/). We obtained 1000 responses from developer and developer-adjacent roles.
+
+Data was analyzed using a Bayesian regression model to quantify the effect of various AI adoption strategies on team-level AI usage.  AI usage was measured as a self-reported percentage of team work supported by AI over the past three months.
+
+The adoption strategies were measured using Likert-scale responses (e.g., 1-7, Strongly Disagree to Strongly Agree). We treated these strategy variables as ordinal predictors. While R's implementation of ordinal regression allows for non-linear relationships (testing for `k-1` curves, where `k` is the number of response levels), we found that the linear effects provided the best balance of interpretability and predictive accuracy.
+
+To isolate the effect of each strategy, we accounted for several potential confounding variables: organizational size, industry, months of individual AI experience, and the presence of other adoption strategies.
+
+The model output provides posterior distributions for the regression coefficients of each strategy. These distributions represent the range of plausible values for the effect of a strategy's presence on the percentage of team work supported by AI, _holding all other variables constant_.

--- a/hugo/content/research/ai/questions.md
+++ b/hugo/content/research/ai/questions.md
@@ -1,0 +1,9 @@
+---
+title: "AI adoption research questions"
+date: 2025-02-04
+updated: 2025-02-04
+research_collection: "ai-adoption"
+research_collection_title: "AI adoption"
+draft: false
+type: "research_archives/questions"
+---

--- a/hugo/content/research/core/questions.md
+++ b/hugo/content/research/core/questions.md
@@ -1,8 +1,9 @@
 ---
 title: "DORA Research Questions"
 date: 2024-10-01
-updated: 2024-10-07
+updated: 2025-02-04
 research_collection: "core"
+research_collection_title: "Core"
 draft: false
 tab_order: "10"
 tab_title: "Questions"

--- a/hugo/data/survey_questions/ai-adoption.json
+++ b/hugo/data/survey_questions/ai-adoption.json
@@ -18,7 +18,6 @@
                         "My organization is committed to the professional development of its employees.",
                         "My organization requires employees to complete trainings that provide no inside or outside value to their job roles.",
                         "My organization is transparent about how AI is being used.",
-                        "My organization has developed metrics for measuring the impact AI has on employee productivity",
                         "My organization's leadership has clear goals regarding how it expects AI to impact organizational performance"
                     ]
                 }

--- a/hugo/data/survey_questions/ai-adoption.json
+++ b/hugo/data/survey_questions/ai-adoption.json
@@ -1,0 +1,160 @@
+{
+    "categories": [
+        {
+            "heading": "AI adoption",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has policies that govern the adoption of AI-powered tools and services.",
+                        "My organization has policies that allow employees to clearly understand how and when to use AI tools.",
+                        "My organization provides guidelines regarding how to mitigate security and privacy risks when engaging with AI",
+                        "My organization has proactively established safeguards against security and privacy breaches when utilizing AI.",
+                        "My organization has taken concrete steps to alleviate developers' worries about job displacement as a result of AI adoption.",
+                        "My organization allows employees to take time during their work hours to learn to use AI tools.",
+                        "My organization actively encourages employees to incorporate AI tools into their workflow.",
+                        "My organization provides resources (courses, webinars, etc.) for employees to learn how to best incorporate AI into their workflows.",
+                        "My organization is committed to the professional development of its employees.",
+                        "My organization requires employees to complete trainings that provide no inside or outside value to their job roles.",
+                        "My organization is transparent about how AI is being used.",
+                        "My organization has developed metrics for measuring the impact AI has on employee productivity",
+                        "My organization's leadership has clear goals regarding how it expects AI to impact organizational performance"
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Clear AI policies",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has policies that govern the adoption of AI-powered tools and services."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Policies on when and where to use AI",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has policies that allow employees to clearly understand how and when to use AI tools."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Guidelines to mitigate privacy issues",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization provides guidelines regarding how to mitigate security and privacy risks when engaging with AI"
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Safeguards against sec & privacy breaches",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has proactively established safeguards against security and privacy breaches when utilizing AI."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Alleviate displacement worries",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has taken concrete steps to alleviate developers' worries about job displacement as a result of AI adoption."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Time to learn",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization allows employees to take time during their work hours to learn to use AI tools."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Encourage AI in workflows",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization actively encourages employees to incorporate AI tools into their workflow."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Resources to learn about AI",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization provides resources (courses, webinars, etc.) for employees to learn how to best incorporate AI into their workflows."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Invest in employee development",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization is committed to the professional development of its employees."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Mandatory trainings",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization requires employees to complete trainings that provide no inside or outside value to their job roles."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "Transparent about AI plans",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization is transparent about how AI is being used."
+                    ]
+                }
+            ]
+        },
+        {
+            "heading": "AI adoption goals",
+            "question_groups": [
+                {
+                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "questions": [
+                        "My organization has developed metrics for measuring the impact AI has on employee productivity",
+                        "My organization's leadership has clear goals regarding how it expects AI to impact organizational performance"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/hugo/data/survey_questions/ai-adoption.json
+++ b/hugo/data/survey_questions/ai-adoption.json
@@ -1,9 +1,10 @@
 {
     "categories": [
         {
-            "heading": "AI adoption",
+            "heading": "Organizational practices",
             "question_groups": [
                 {
+                    "description": "Rate how strongly you agree or disagree with the following statements.",
                     "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
                     "questions": [
                         "My organization has policies that govern the adoption of AI-powered tools and services.",
@@ -24,134 +25,12 @@
             ]
         },
         {
-            "heading": "Clear AI policies",
+            "heading": "AI adoption",
             "question_groups": [
                 {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
+                    "group_responses": "value between 0% and 100%,Empty if NA or you prefer not to answer.",
                     "questions": [
-                        "My organization has policies that govern the adoption of AI-powered tools and services."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Policies on when and where to use AI",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization has policies that allow employees to clearly understand how and when to use AI tools."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Guidelines to mitigate privacy issues",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization provides guidelines regarding how to mitigate security and privacy risks when engaging with AI"
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Safeguards against sec & privacy breaches",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization has proactively established safeguards against security and privacy breaches when utilizing AI."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Alleviate displacement worries",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization has taken concrete steps to alleviate developers' worries about job displacement as a result of AI adoption."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Time to learn",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization allows employees to take time during their work hours to learn to use AI tools."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Encourage AI in workflows",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization actively encourages employees to incorporate AI tools into their workflow."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Resources to learn about AI",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization provides resources (courses, webinars, etc.) for employees to learn how to best incorporate AI into their workflows."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Invest in employee development",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization is committed to the professional development of its employees."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Mandatory trainings",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization requires employees to complete trainings that provide no inside or outside value to their job roles."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "Transparent about AI plans",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization is transparent about how AI is being used."
-                    ]
-                }
-            ]
-        },
-        {
-            "heading": "AI adoption goals",
-            "question_groups": [
-                {
-                    "group_responses": "Strongly disagree,Disagree,Somewhat disagree,Neither agree nor disagree,Somewhat agree,Agree,Strongly agree,I don't know or NA",
-                    "questions": [
-                        "My organization has developed metrics for measuring the impact AI has on employee productivity",
-                        "My organization's leadership has clear goals regarding how it expects AI to impact organizational performance"
+                        "Over the last 3 months, approximately what percentage of your team's work is supported by AI?"
                     ]
                 }
             ]

--- a/hugo/layouts/research_archives/questions/single.html
+++ b/hugo/layouts/research_archives/questions/single.html
@@ -1,9 +1,14 @@
 {{ define "main" }}
 {{- partial "partials/link_styles" "scss/research.scss" -}}
 
-{{ $researchYear := .Params.research_collection }}
+{{ $researchCollectionTitle := "" }}
+{{ if .Params.research_collection_title }}
+  {{ $researchCollectionTitle = .Params.research_collection_title }}
+{{ else }}
+    {{ $researchCollectionTitle = .Params.research_collection }}
+{{ end }}
 
-<h1>DORA Research: {{ .Params.research_collection }}</h1>
+<h1>DORA Research: {{ $researchCollectionTitle }}</h1>
 {{- partial "research_archives_tabs" . -}}
 
         {{ .Content }}
@@ -11,10 +16,12 @@
 <section class="hasSidebar">
     <article id="questions">
         <h2>Survey Questions</h2>
-        {{ if eq $researchYear "core" }}
-          <h4>Responses to the following questions were used in the analysis of the <a href="/research/">DORA Core Model</a>.</h4>
+        {{ if eq .Params.research_collection "core" }}
+            <h4>Responses to the following questions were used in the analysis of the <a href="/research/">DORA Core Model</a>.</h4>
+        {{ else if eq  .Params.research_collection "ai-adoption" }}
+            <h4>Responses to the following questions were used in the analysis of <a href="/research/ai/adopt-gen-ai">Helping developers adopt generative AI: Four practical strategies for organizations</a>.</h4>
         {{ else }}
-            <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchYear }}/dora-report/">{{ $researchYear }} Accelerate State of DevOps Report</a>.</h4>
+            <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchCollectionTitle }}/dora-report/">{{ $researchCollectionTitle }} Accelerate State of DevOps Report</a>.</h4>
         {{ end }}
         {{ with index .Site.Data.survey_questions .Params.research_collection }}
             {{  range sort .categories "heading" }}

--- a/hugo/layouts/research_archives/questions/single.html
+++ b/hugo/layouts/research_archives/questions/single.html
@@ -19,7 +19,7 @@
         {{ if eq .Params.research_collection "core" }}
             <h4>Responses to the following questions were used in the analysis of the <a href="/research/">DORA Core Model</a>.</h4>
         {{ else if eq  .Params.research_collection "ai-adoption" }}
-            <h4>Responses to the following questions were used in the analysis of <a href="/research/ai/adopt-gen-ai">Helping developers adopt generative AI: Four practical strategies for organizations</a>.</h4>
+            <h4>Responses to the following questions were used in the analysis for <a href="/research/ai/adopt-gen-ai">Helping developers adopt generative AI: Four practical strategies for organizations</a>.</h4>
         {{ else }}
             <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchCollectionTitle }}/dora-report/">{{ $researchCollectionTitle }} Accelerate State of DevOps Report</a>.</h4>
         {{ end }}

--- a/test/playwright/tests/research/ai/ai-adoption-questions.spec.ts
+++ b/test/playwright/tests/research/ai/ai-adoption-questions.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { sidebarLinks } from '../sidebarLinks';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/research/ai/questions/');
+});
+
+test('AI adoption survey questions page has the correct title.', async ({ page }) => {
+  await expect(page).toHaveTitle('DORA | AI adoption research questions');
+});
+
+test('AI adoption questions page lists the correct research collection.', async ({ page }) => {
+  await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis of Helping developers adopt generative AI: Four practical strategies for organizations.');
+});
+
+test('AI adoption survey questions page has the correct sidebar.', async ({ page }) => {
+  for (const sidebarLink of sidebarLinks) {
+    await expect(page.getByRole('link', { name: sidebarLink, exact: true })).toBeVisible();
+  }
+});
+
+test('AI adoption survey questions page displays its last updated date', async ({ page }) => {
+  await expect(page.locator('.updated')).toContainText('Last updated: ')
+});

--- a/test/playwright/tests/research/ai/ai-adoption-questions.spec.ts
+++ b/test/playwright/tests/research/ai/ai-adoption-questions.spec.ts
@@ -10,7 +10,7 @@ test('AI adoption survey questions page has the correct title.', async ({ page }
 });
 
 test('AI adoption questions page lists the correct research collection.', async ({ page }) => {
-  await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis of Helping developers adopt generative AI: Four practical strategies for organizations.');
+  await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis for Helping developers adopt generative AI: Four practical strategies for organizations.');
 });
 
 test('AI adoption survey questions page has the correct sidebar.', async ({ page }) => {

--- a/test/playwright/tests/research/core/core-questions.spec.ts
+++ b/test/playwright/tests/research/core/core-questions.spec.ts
@@ -5,24 +5,24 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/research/core/questions/');
 });
 
-test('core questions page has the correct title.', async ({ page }) => {
+test('Core questions page has the correct title.', async ({ page }) => {
   await expect(page).toHaveTitle('DORA | DORA Research Questions');
 });
 
-test('core questions page has the correct header.', async ({ page }) => {
-  await expect(page.locator('h1')).toContainText('DORA Research: core');
+test('Core questions page has the correct header.', async ({ page }) => {
+  await expect(page.locator('h1')).toContainText('DORA Research: Core');
 });
 
-test('core questions page lists the correct report.', async ({ page }) => {
+test('Core questions page lists the correct report.', async ({ page }) => {
     await expect(page.locator('h4')).toContainText('Responses to the following questions were used in the analysis of the DORA Core Model.');
 });
 
-test('core questions page has the correct sidebar.', async ({ page }) => {
+test('Core questions page has the correct sidebar.', async ({ page }) => {
   for (const sidebarLink of sidebarLinks) {
     await expect(page.getByRole('link', { name: sidebarLink, exact: true })).toBeVisible();
   }
 });
 
-test('core questions page displays its last updated date', async ({ page }) => {
+test('Core questions page displays its last updated date', async ({ page }) => {
   await expect(page.locator('.updated')).toContainText('Last updated: ')
 });


### PR DESCRIPTION
* Add the questions used for researching AI adoption
* Update the AI adoption article to link to the questions
* Changes to the layout of questions (impacts annual research and core questions)
* Adds new frontmatter parameter: `research_collection_title` used by core and AI adoption questions.
* Adds and updates tests

Preview links

* https://doradotdev--pr873-drafts-off-hyx2vneq.web.app/research/ai/adopt-gen-ai/#notes-on-method
* https://doradotdev--pr873-drafts-off-hyx2vneq.web.app/research/ai/questions/
* https://doradotdev--pr873-drafts-off-hyx2vneq.web.app/research/core/questions/