### PR TITLE
Better handling of PDF titles in search index.

### DIFF
--- a/hugo/content/search/search.js
+++ b/hugo/content/search/search.js
@@ -33,7 +33,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
         resultsBox.innerHTML = `<span class="searching">Searching "${searchTerm}..."</span>`;
         console.log(`searching ${searchTerm}...`)
         searchURI = `${searchServer}?query=${searchTerm}&max_web_records=${max_web_records}`;
-        
+
         fetch(searchURI)
             .then(response => {
                 if (!response.ok) {
@@ -90,6 +90,14 @@ window.addEventListener('DOMContentLoaded', (event) => {
             year = result.publication_year;
             snippet = result.snippet;
             page_number = result.page_number;
+            let title = ""
+            if (year === "2020") {
+                title = "ROI of DevOps Transformation"
+            } else if (year < 2018) {
+                title = `State of DevOps Report ${year}`
+            } else {
+                title = `Accelerate State of DevOps Report ${year}`
+            }
             // URL `/dora-report-${year}` requires Firebase redirect, so it won't work if site is served by Hugo
             publicationResultsBox.innerHTML += `
             <a href="/dora-report-${year}" target="_blank">
@@ -97,7 +105,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
                     <div class="thumbnail">
                         <img src="/img/sodr_thumbnails/${year}.png">
                         <br>
-                        <h3>State of DevOps Report ${year}</h3>
+                        <h3>${title}</h3>
                         <h4>p. ${page_number}</h4>
                     </div>
                     <div class="snippet">


### PR DESCRIPTION
This adds some logic for PDF titles on the search results page.

* Before 2018 - State of DevOps Report
* 2018 and later - Accelerate State of DevOps Report 
* 2020 - ROI of DevOps Transformation

This supports https://github.com/dora-team/search.dora.dev/issues/16 and https://github.com/dora-team/search.dora.dev/issues/17

Preview URL - https://doradotdev--pr886-drafts-off-xh0hd3qc.web.app/search/?q=roi

Comparison URL - https://dora.dev/search/?q=roi

This search result should show all three title sytles.
