### PR TITLE
#207 remove redundant styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ svelte/quick-check-2023/dist/
 svelte/core-v2/dist/**
 
 .venv/**
+
+# IDE files
+.idea/

--- a/hugo/assets/scss/capabilities.scss
+++ b/hugo/assets/scss/capabilities.scss
@@ -166,12 +166,6 @@ h1 a.core {
 
 @include media-medium {
     .capabilitiesGrid {
-        grid-template-columns: 1fr 1fr;
-    }
-}
-
-@include media-medium {
-    .capabilitiesGrid {
         grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
Fix #207 

Hi, :wave: 

Thank you for providing such a useful material!

The goal of this PR is to remove a style always overridden. When reducing the width of the web browser, the table switch to one column instead of two. No visual change is witnessed following the style change.

![Capture d’écran du 2025-02-11 19-41-01](https://github.com/user-attachments/assets/fd8860fa-6bbc-44d0-9e81-cac1c4d4bcaa)

This PR also adds an exclusion of an IDE folder from versioning.

Please note this is my first PR to this project. I watched the video in the README beforehand but do not hesitate to point to me anything that I may have missed.