### PR TITLE
Updates to the documentation quality article

### DIFF
--- a/hugo/content/capabilities/documentation-quality/index.md
+++ b/hugo/content/capabilities/documentation-quality/index.md
@@ -20,11 +20,11 @@ summary: |
 Internal documentation is a fundamental part of software development. Analysis by DORA has found a clear link between documentation quality and organizational performance — the organization’s ability to meet their performance and profitability goals. Documentation is highly technical work, and our findings show just how much this work pays off.
 
 ## Measuring documentation quality
-For our research, we used a set of eight metrics that assess documentation attributes like clarity, findability, and reliability. You can review the [questions from 2022](/research/archives/2022/?tab_archives=questions) for the statements we used to assess these attributes.
+For our research, we used a set of eight metrics that assess documentation attributes like clarity, findability, and reliability. You can review the [questions from 2022](/research/2022/questions/) for the statements we used to assess these attributes.
 
 
 ## The impact of documentation
-Similar to our research from 2021, we see documentation quality driving the implementation of every single technical practice we studied. [Our model from 2022](/research/archives/2022/?tab_archives=structural-equation-model) shows documentation underpinning these technical capabilities.
+Similar to our research from 2021, we see documentation quality driving the implementation of every single technical practice we studied. [Our model from 2022](/research/2022/structural-equation-model/) shows documentation underpinning these technical capabilities.
 
 What may be more exciting, however, is how documentation quality interacts with these capabilities to impact organizational performance.
 
@@ -46,7 +46,7 @@ This interaction and impact applies to every single technical capability we stud
 ## Creating quality documentation
 Documentation needs to be actively created and maintained, which takes work.
 
-For guidance from our research, you can review the [2021 State of DevOps Report](/research/2021/dora-report/2021-dora-accelerate-state-of-devops-report.pdf) for practices that you can implement to improve documentation quality.
+For guidance from our research, you can review the [2021 State of DevOps Report](/research/2021/dora-report/) for practices that you can implement to improve documentation quality.
 
 This research doesn’t investigate individual resources, but there are plenty out there to help you create useful documentation. In your own organization, you may have documentation guidelines and training. You may also have technical writers or other documentation champions to work with. Here at Google, our documentation resources include:
 

--- a/test/playwright/tests/capabilities/documentation-quality.spec.ts
+++ b/test/playwright/tests/capabilities/documentation-quality.spec.ts
@@ -1,33 +1,44 @@
 import { test, expect } from '@playwright/test';
 
-test('Documentation quality page loads correctly', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/capabilities/documentation-quality/');
+});
 
-  // Check for page title
+test('Documentation quality page loads correctly', async ({ page }) => {
   await expect(page).toHaveTitle('DORA | Capabilities: Documentation quality');
-
-  // Check for page heading
   await expect(page.locator('h1')).toContainText('Documentation quality');
+});
 
-  // Check for table
+test('Documentation quality page displays table', async ({ page }) => {
   await expect(page.locator('table')).toBeVisible();
+});
 
-  // Check for links
-  await expect(page.locator('a[href="/research/archives/2022/?tab_archives=questions"]')).toBeVisible();
-  await expect(page.locator('a[href="/research/archives/2022/?tab_archives=structural-equation-model"]')).toBeVisible();
-  await expect(page.locator('a[href="/research/2021/dora-report/2021-dora-accelerate-state-of-devops-report.pdf"]')).toBeVisible();
-  await expect(page.locator('a[href="https://developers.google.com/tech-writing"]')).toBeVisible();
-  await expect(page.locator('a[href="https://developers.google.com/style"]')).toBeVisible();
-  await expect(page.locator('a[href="https://www.oreilly.com/library/view/software-engineering-at/9781492082781/"]')).toBeVisible();
-  await expect(page.locator('a[href="https://cloud.google.com/blog/products/devops-sre/deep-dive-into-2022-state-of-devops-report-on-documentation"]')).toBeVisible();
-  await expect(page.locator('a[href="/research/team/#michelle-irvine"]')).toBeVisible();
-  await expect(page.locator('a[href="/research/team/#derek-debellis"]')).toBeVisible();
 
-  //Check the sidebar
-  await expect(page.getByRole('heading', { name: 'Climate for Learning', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Fast Flow', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Fast Feedback', exact: true })).toBeVisible();
+test('Documentation quality page contains all expected links', async ({ page }) => {
+  const links = [
+    '/research/2022/questions/',
+    '/research/2022/structural-equation-model/',
+    '/research/2021/dora-report/',
+    'https://developers.google.com/tech-writing',
+    'https://developers.google.com/style',
+    'https://www.oreilly.com/library/view/software-engineering-at/9781492082781/',
+    'https://cloud.google.com/blog/products/devops-sre/deep-dive-into-2022-state-of-devops-report-on-documentation',
+    '/research/team/#michelle-irvine',
+    '/research/team/#derek-debellis',
+  ];
 
-  // This is a core capability
+  for (const link of links) {
+    await expect(page.locator(`a[href="${link}"]`)).toBeVisible();
+  }
+});
+
+test('Documentation quality page contains all expected headings', async ({ page }) => {
+  const headings = ['Climate for Learning', 'Fast Flow', 'Fast Feedback'];
+  for (const heading of headings) {
+    await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible();
+  }
+});
+
+test('Documentation quality page contains "core" link', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'core', exact: true })).toBeVisible();
 });

--- a/test/redirects/README.md
+++ b/test/redirects/README.md
@@ -15,8 +15,3 @@ Optionally set a `BASE_URL` environment varilable to test redirects against a di
 
 `BASE_URL=https://staging.dora.dev npx mocha test-redirects.js`
 `docker run -it --env BASE_URL=https://staging.dora.dev test-redirects`
-
-## TODO
-The following cases need to be handled:
-
-"source": "/research/:year/?tab_archives=:tab", "destination": "/research/:year/:tab", "type": 302


### PR DESCRIPTION
* Fix a link to the 2022 questions
* Fix a link to the 2022 SEM
* Fix a link to the 2021 report
* Refactors the playwright tests for the page
* Removes a TODO from the redirect tests

Preview - https://doradotdev--pr893-drafts-off-5cqsl6y7.web.app/capabilities/documentation-quality/