### PR TITLE
2024 report is available in multiple languages

### DIFF
--- a/hugo/content/research/2024/dora-report/index.md
+++ b/hugo/content/research/2024/dora-report/index.md
@@ -18,7 +18,6 @@ type: "research_archives"
 </item>
 <item>
   <h4>The 2024 DORA Report is available in the following languages:</h4>
-
   <ul>
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=en&region=US" target="_blank">English</a></li>
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=es&region=ES" target="_blank">Español</a></li>
@@ -26,7 +25,8 @@ type: "research_archives"
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=fr&region=FR" target="_blank">Français</a></li>
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=it&region=IT" target="_blank">Italiano</a></li>
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=pt-br&region=BR" target="_blank">Português - Brasil</a></li>
-    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW" target="_blank">中文 – 简体</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=zh-cn&region=CN" target="_blank">中文 – 简体</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW" target="_blank">繁體中文</a></li>
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=ja&region=JP" target="_blank">日本語</a></li>
     <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=ko&region=KR" target="_blank">한국어</a></li>
   </ul>

--- a/hugo/content/research/2024/dora-report/index.md
+++ b/hugo/content/research/2024/dora-report/index.md
@@ -16,18 +16,26 @@ type: "research_archives"
 <a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><img src="2024-dora-accelerate-state-of-devops-report.png" alt="Accelerate State of DevOps Report 2024" style="max-width:24em;"></a>
 
 </item>
-
 <item>
-<p>
-DORA has been investigating the capabilities, practices, and measures of high-performing technology-driven teams and organizations for over a decade. This is our tenth DORA report. We have heard from more than 39,000 professionals working at organizations of every size and across many different industries globally.
-</p>
-<p>
-This report highlights the significant impact of AI on software development, explores platform engineering’s promises and challenges, and emphasizes user-centricity and stable priorities for organizational success.
-</p>
-<p>
-<a href="https://cloud.google.com/devops/state-of-devops" target="_blank"><button class="secondary">Download the report</button></a>
-</p>
+  <h4>The 2024 DORA Report is available in the following languages:</h4>
+
+  <ul>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=en&region=US" target="_blank">English</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=es&region=ES" target="_blank">Español</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=es-419&region=MX" target="_blank">Español - América Latina</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=fr&region=FR" target="_blank">Français</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=it&region=IT" target="_blank">Italiano</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=pt-br&region=BR" target="_blank">Português - Brasil</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW" target="_blank">中文 – 简体</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=ja&region=JP" target="_blank">日本語</a></li>
+    <li style="font-size:1.25rem;"><a href="https://cloud.google.com/devops/state-of-devops/?hl=ko&region=KR" target="_blank">한국어</a></li>
+  </ul>
+</item>
 </grid>
+
+DORA has been investigating the capabilities, practices, and measures of high-performing technology-driven teams and organizations for over a decade. This is our tenth DORA report. We have heard from more than 39,000 professionals working at organizations of every size and across many different industries globally.
+
+This report highlights the significant impact of AI on software development, explores platform engineering’s promises and challenges, and emphasizes user-centricity and stable priorities for organizational success.
 
 ### Gold Sponsors
 

--- a/test/playwright/tests/research/2024/2024-dora-report.spec.ts
+++ b/test/playwright/tests/research/2024/2024-dora-report.spec.ts
@@ -8,7 +8,8 @@ const languageToUrlMap = {
   'Français': 'https://cloud.google.com/devops/state-of-devops/?hl=fr&region=FR',
   'Italiano': 'https://cloud.google.com/devops/state-of-devops/?hl=it&region=IT',
   'Português - Brasil': 'https://cloud.google.com/devops/state-of-devops/?hl=pt-br&region=BR',
-  '中文 – 简体': 'https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW' ,
+  '中文 – 简体': 'https://cloud.google.com/devops/state-of-devops/?hl=zh-cn&region=CN' ,
+  '繁體中文': 'https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW',
   '日本語': 'https://cloud.google.com/devops/state-of-devops/?hl=ja&region=JP',
   '한국어': 'https://cloud.google.com/devops/state-of-devops/?hl=ko&region=KR'
 };

--- a/test/playwright/tests/research/2024/2024-dora-report.spec.ts
+++ b/test/playwright/tests/research/2024/2024-dora-report.spec.ts
@@ -1,6 +1,18 @@
 import { test, expect } from '@playwright/test';
 import { sidebarLinks } from '../sidebarLinks';
 
+const languageToUrlMap = {
+  'English': 'https://cloud.google.com/devops/state-of-devops/?hl=en&region=US',
+  'Español': 'https://cloud.google.com/devops/state-of-devops/?hl=es&region=ES',
+  'Español - América Latina': 'https://cloud.google.com/devops/state-of-devops/?hl=es-419&region=MX',
+  'Français': 'https://cloud.google.com/devops/state-of-devops/?hl=fr&region=FR',
+  'Italiano': 'https://cloud.google.com/devops/state-of-devops/?hl=it&region=IT',
+  'Português - Brasil': 'https://cloud.google.com/devops/state-of-devops/?hl=pt-br&region=BR',
+  '中文 – 简体': 'https://cloud.google.com/devops/state-of-devops/?hl=zh-tw&region=TW' ,
+  '日本語': 'https://cloud.google.com/devops/state-of-devops/?hl=ja&region=JP',
+  '한국어': 'https://cloud.google.com/devops/state-of-devops/?hl=ko&region=KR'
+};
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/research/2024/dora-report/');
 });
@@ -12,6 +24,21 @@ test('2024 research overview has the correct title.', async ({ page }) => {
 test('2024 research overview has the correct header.', async ({ page }) => {
   await expect(page.locator('h1')).toContainText('DORA Research: 2024');
 });
+
+test('2024 DORA report page has the correct number of language options.', async ({ page }) => {
+  const languageOptions = await page.locator('item ul li').count();
+  const expectedLanguageCount = Object.keys(languageToUrlMap).length;
+  await expect(languageOptions).toBe(expectedLanguageCount);
+});
+
+for (const language in languageToUrlMap) {
+  const url = languageToUrlMap[language];
+  test(`2024 DORA report is available in ${language}`, async ({ page }) => {
+    const url = languageToUrlMap[language];
+    const languageLink = page.getByRole('link', { name: language, exact: true });
+    await expect(languageLink).toHaveAttribute('href', url);
+  });
+}
 
 test('2024 research overview has the correct sidebar.', async ({ page }) => {
   for (const sidebarLink of sidebarLinks) {


### PR DESCRIPTION
* Adds language-specific links to the report page
* Removes the "download the report" button
* Updates tests

Preview URL - https://doradotdev--pr908-drafts-off-46hj9clc.web.app/research/2024/dora-report/