### PR TITLE
UI tests for alpine mechanisms  (Fixes #729)

### DIFF
--- a/test/playwright/tests/research/2024/2024-navigation.spec.ts
+++ b/test/playwright/tests/research/2024/2024-navigation.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+// validate navigation within the "research" section (using 2024 as a representative page) 
+// check that sidebar links and tabs works
+test('test', async ({ page }) => {
+  await page.goto('/research/');
+  await page.getByRole('link', { name: '2024', exact: true }).click();
+  await page.getByRole('link', { name: 'DORA Report', exact: true }).click();
+  await expect(page.locator('h2')).toContainText('Download the 2024 DORA Report');
+});

--- a/test/playwright/tests/research/2024/2024-navigation.spec.ts
+++ b/test/playwright/tests/research/2024/2024-navigation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 // validate navigation within the "research" section (using 2024 as a representative page) 
 // check that sidebar links and tabs works
-test('test', async ({ page }) => {
+test('researchNavigation2024', async ({ page }) => {
   await page.goto('/research/');
   await page.getByRole('link', { name: '2024', exact: true }).click();
   await page.getByRole('link', { name: 'DORA Report', exact: true }).click();

--- a/test/playwright/tests/research/2024/2024-navigation.spec.ts
+++ b/test/playwright/tests/research/2024/2024-navigation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 // validate navigation within the "research" section (using 2024 as a representative page) 
 // check that sidebar links and tabs works
-test('researchNavigation2024', async ({ page }) => {
+test('2024 Research navigation is functional', async ({ page }) => {
   await page.goto('/research/');
   await page.getByRole('link', { name: '2024', exact: true }).click();
   await page.getByRole('link', { name: 'DORA Report', exact: true }).click();


### PR DESCRIPTION
As far as I can tell/remember, the only remaining place where Alpine is used is in the `tab_navigation` partial. _And_ the `tab_navigation` partial is actually not used any more (it was last used on the legacy quick check which has now been removed -- see #911). The research pages have a newer/simpler tab implementation which doesn't use JS. (it's in `partials/research_archives_tabs.html`)

So adding this test isn't _actually_ related to Alpine, but it does relate to functionality that Alpine once provided, and it's a good check to have.