### PR TITLE
Add version checker for printed gen AI reports

### DIFF
--- a/hugo/content/vc/genai/index.md
+++ b/hugo/content/vc/genai/index.md
@@ -20,6 +20,9 @@ bannerSubtitle: "Check if you have the most recent version of the report."
   <p>The following versions of the Impact of Generative AI on Software Development report are available via this version checker:</p>
   <ul>
     <li>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc/genai/?v=2025.1.p">Impact of Generative AI on Software Development (Printed Version) <code>v. 2025.1.p</code></a>
+    </li>
+    <li>
       <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc/genai/?v=2025.1">Impact of Generative AI on Software Development <code>v. 2025.1</code></a>
     </li>
   </ul>
@@ -36,6 +39,23 @@ bannerSubtitle: "Check if you have the most recent version of the report."
     Latest version: <code>v.2025.1</code>
   </p>
 </div>
+
+<!-- version is 2025.1.p -->
+<div class="version-content" data-version="2025.1.p">
+  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>Impact of Generative AI on Software Development (Printed Version)</h2>
+  <p>
+    You have the most recent printed version of the Impact of Generative AI on Software Development report.
+  </p>
+  <p>
+    Your version: <code>v.2025.1.p</code><br />
+    Latest version: <code>v.2025.1.p</code>
+  </p>
+  <p>
+    <a href="/research/ai/gen-ai-report/">Download the latest digital version of the Impact of Generative AI on Software Development</a>.
+  </p>
+  <a href="/research/ai/gen-ai-report/"><img src="/research/ai/gen-ai-report/dora-impact-of-generative-ai-in-software-development-report.png" alt="Impact of Generative AI on Software Development Cover" style="max-width:18em;"></a>
+</div>
+
 
 <script src="/js/version-check-utils.js"></script>
 <script>

--- a/test/playwright/tests/vc/genai-version-check.spec.ts
+++ b/test/playwright/tests/vc/genai-version-check.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const versions = [
   { version: '2025.1', expectedText: 'Impact of Generative AI on Software Development' },
+  { version: '2025.1.p', expectedText: 'Impact of Generative AI on Software Development (Printed Version)' }
 ];
 
 versions.forEach(({ version, expectedText }) => {
@@ -9,7 +10,11 @@ versions.forEach(({ version, expectedText }) => {
     await page.goto(`/vc/genai/?v=${version}`);
 
     // Check the correct version is displayed
-    await expect(page.locator(`div[data-version="${version}"]`)).toBeVisible();
+    const versionDiv = page.locator(`div[data-version="${version}"]`);
+    await expect(versionDiv).toBeVisible();
+
+    // Check the correct header text is displayed
+    await expect(versionDiv.locator('h2')).toContainText(expectedText);
 
     // Check other versions are hidden
     versions

--- a/test/playwright/tests/vc/version-check.spec.ts
+++ b/test/playwright/tests/vc/version-check.spec.ts
@@ -13,8 +13,11 @@ versions.forEach(({ version, expectedText }) => {
   test(`Version checker recognizes v ${version}`, async ({ page }) => {
     await page.goto(`/vc/?v=${version}`);
 
-    // Check the correct version is displayed
-    await expect(page.locator(`div[data-version="${version}"]`)).toBeVisible();
+    const versionDiv = page.locator(`div[data-version="${version}"]`);
+    await expect(versionDiv).toBeVisible();
+
+    // Check the correct header text is displayed
+    await expect(versionDiv.locator('h2')).toContainText(expectedText);
 
     // Check other versions are hidden
     versions


### PR DESCRIPTION
* Updates the gen AI report version checker
* Adds tests to the version checker for the gen AI report
* Updates a test for the DORA Report version checker to check the expected text, previously only the version number was being validated.

Preview URLs:
* https://doradotdev--pr923-drafts-off-i6d4sqv1.web.app/vc/genai/
* https://doradotdev--pr923-drafts-off-i6d4sqv1.web.app/vc/genai/?v=2025.1.p