### PR TITLE
One errata for the gen ai report

### DIFF
--- a/hugo/content/research/ai/errata.md
+++ b/hugo/content/research/ai/errata.md
@@ -11,6 +11,10 @@ type: "research_archives"
 
 This page lists errors and corrections to the Impact of Generative AI in Software Development. To track revisions, report PDFs are stamped with a version number. The current version of the report is [`v.2025.1`](/research/ai/gen-ai-report).
 
+### Errata in `v.2025.1`
+
+**p. 49** The word "acquire" is broken with a line break. The sentence should read "Frame AI as an opportunity for developers to acquire new skills and expand their expertise."
+
 -----
 <div style="text-align:center; margin-top:2em;">
 Have you found an error the Impact of Generative AI in Software Development?


### PR DESCRIPTION
"acquire" should not be split across lines.

Preview: https://doradotdev--pr951-drafts-off-5q1pvq0p.web.app/research/ai/errata/