### PR TITLE
v. 2025.2 of the gen ai report is available

### DIFF
--- a/hugo/content/research/ai/errata.md
+++ b/hugo/content/research/ai/errata.md
@@ -9,11 +9,11 @@ tab_title: "Errata"
 type: "research_archives"
 ---
 
-This page lists errors and corrections to the Impact of Generative AI in Software Development. To track revisions, report PDFs are stamped with a version number. The current version of the report is [`v.2025.1`](/research/ai/gen-ai-report).
+This page lists errors and corrections to the Impact of Generative AI in Software Development. To track revisions, report PDFs are stamped with a version number. The current version of the report is [`v.2025.2`](/research/ai/gen-ai-report).
 
 ### Errata in `v.2025.1`
 
-**p. 49** The word "acquire" is broken with a line break. The sentence should read "Frame AI as an opportunity for developers to acquire new skills and expand their expertise."
+**p. 49** The word "acquire" is broken with a line break. The sentence should read "Frame AI as an opportunity for developers to acquire new skills and expand their expertise." _[Corrected in `v.2025.2`]_
 
 -----
 <div style="text-align:center; margin-top:2em;">

--- a/hugo/content/vc/genai/index.md
+++ b/hugo/content/vc/genai/index.md
@@ -20,35 +20,53 @@ bannerSubtitle: "Check if you have the most recent version of the report."
   <p>The following versions of the Impact of Generative AI on Software Development report are available via this version checker:</p>
   <ul>
     <li>
-      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc/genai/?v=2025.1.p">Impact of Generative AI on Software Development (Printed Version) <code>v. 2025.1.p</code></a>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc/genai/?v=2025.2">Impact of Generative AI on Software Development <code>v. 2025.2</code></a>
     </li>
     <li>
-      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc/genai/?v=2025.1">Impact of Generative AI on Software Development <code>v. 2025.1</code></a>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc/genai/?v=2025.2.p">Impact of Generative AI on Software Development (Printed Version) <code>v. 2025.2.p</code></a>
+    </li>
+    <li>
+      <span class="google-material-icons" style="color: orange; font-size:1em;">warning</span> <a href="/vc/genai/?v=2025.1">Impact of Generative AI on Software Development <code>v. 2025.1</code></a>
     </li>
   </ul>
 </div>
 
-<!-- version is 2025.1 -->
-<div class="version-content" data-version="2025.1">
+<!-- version is 2025.2 -->
+<div class="version-content" data-version="2025.2">
   <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>Impact of Generative AI on Software Development</h2>
   <p>
     You have the most recent version of the Impact of Generative AI on Software Development report.
   </p>
   <p>
-    Your version: <code>v.2025.1</code><br />
-    Latest version: <code>v.2025.1</code>
+    Your version: <code>v.2025.2</code><br />
+    Latest version: <code>v.2025.2</code>
   </p>
 </div>
 
-<!-- version is 2025.1.p -->
-<div class="version-content" data-version="2025.1.p">
+<!-- version is 2025.1 -->
+<div class="version-content" data-version="2025.1">
+  <h2><span class="google-material-icons" style="color: orange; font-size:1em;">warning</span>Outdated Impact of Generative AI on Software Development</h2>
+  <p>
+    You have an older version of the Impact of Generative AI on Software Development report.
+  </p>
+  <p>
+    Your version: <code>v.2025.1</code><br />
+    Latest version: <code>v.2025.2</code>
+  </p>
+  <p>
+    <a href="/research/ai/gen-ai-report">Download the latest version of the Impact of Generative AI on Software Development report</a>.
+  </p>
+</div>
+
+<!-- version is 2025.2.p -->
+<div class="version-content" data-version="2025.2.p">
   <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>Impact of Generative AI on Software Development (Printed Version)</h2>
   <p>
     You have the most recent printed version of the Impact of Generative AI on Software Development report.
   </p>
   <p>
-    Your version: <code>v.2025.1.p</code><br />
-    Latest version: <code>v.2025.1.p</code>
+    Your version: <code>v.2025.2.p</code><br />
+    Latest version: <code>v.2025.2.p</code>
   </p>
   <p>
     <a href="/research/ai/gen-ai-report/">Download the latest digital version of the Impact of Generative AI on Software Development</a>.

--- a/test/playwright/tests/vc/genai-version-check.spec.ts
+++ b/test/playwright/tests/vc/genai-version-check.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 const versions = [
+  { version: '2025.2', expectedText: 'Impact of Generative AI on Software Development' },
   { version: '2025.1', expectedText: 'Impact of Generative AI on Software Development' },
-  { version: '2025.1.p', expectedText: 'Impact of Generative AI on Software Development (Printed Version)' }
+  { version: '2025.2.p', expectedText: 'Impact of Generative AI on Software Development (Printed Version)' }
 ];
 
 versions.forEach(({ version, expectedText }) => {


### PR DESCRIPTION
* Update errata page
* Update version checker
* Update tests

Preview URLs:
* Unrecognized - https://doradotdev--pr955-drafts-off-0k5i7hp2.web.app//vc/genai/?v=2025.13
* Latest - https://doradotdev--pr955-drafts-off-0k5i7hp2.web.app//vc/genai/?v=2025.2
* Outdated - https://doradotdev--pr955-drafts-off-0k5i7hp2.web.app//vc/genai/?v=2025.1
* Print - https://doradotdev--pr955-drafts-off-0k5i7hp2.web.app//vc/genai/?v=2025.2.p