### PR TITLE
Fix style corruption due to Core 

### DIFF
--- a/svelte/core-v2/index.html
+++ b/svelte/core-v2/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vite + Svelte</title>
   <style>
-    /* when embedded in the Hugo site, body styles are specified by Hugo theme. these minimal body styles are included here to simulate that inheritence.
+    /* Simulates font inheritance from the Hugo theme.
 
       Be aware that there's a lot more going on in the Hugo site, so other styles may cascade down from the containing page. Look out for interactions.
       */

--- a/svelte/core-v2/index.html
+++ b/svelte/core-v2/index.html
@@ -1,17 +1,43 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Svelte</title>
-    <!-- link to dora.dev stylesheet so that when served by Vite, we will see how it will look when served within the hugo site content -->
-    <!-- this stylesheet downloaded 2024-07-08 -->
-    <!-- <link rel="stylesheet" href="styles-dora-dev_2024-07-08.css" /> -->
-    <link rel="stylesheet" href="//fonts.googleapis.com/css2?family=Google+Sans:wght@200..900">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite + Svelte</title>
+  <style>
+    /* when embedded in the Hugo site, body styles are specified by Hugo theme. these minimal body styles are included here to simulate that inheritence.
+
+      Be aware that there's a lot more going on in the Hugo site, so other styles may cascade down from the containing page. Look out for interactions.
+      */
+
+    @import url("https://fonts.googleapis.com/css2?family=Google+Sans+Flex:opsz,wght@6..144,1..1000&display=swap");
+
+    body {
+      font-family: "Google Sans Flex", Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+      line-height: 1.5;
+
+      color: var(--color-text);
+      background-color: var(--color-background);
+
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+
+      box-sizing: border-box;
+      letter-spacing: normal;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      min-width: 320px;
+    }
+  </style>
 </head>
-  <body>
-    <div id="app" style="width:1040px;"></div>
-    <script type="module" src="/src/main.js"></script>
-  </body>
+
+<body>
+  <div id="app" style="width:1040px;"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+
 </html>

--- a/svelte/core-v2/src/app.css
+++ b/svelte/core-v2/src/app.css
@@ -1,27 +1,5 @@
 @import url("./assets/_variables.css");
 
-:root {
-    font-family: "Google Sans", Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-    line-height: 1.5;
-
-    color: var(--color-text);
-    background-color: var(--color-background);
-
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-
-    box-sizing:border-box;
-    letter-spacing: normal;
-}
-
-body {
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    min-width: 320px;
-}
-
 #app {
     max-width: 1280px;
     margin: 0 auto;


### PR DESCRIPTION
This PR changes the way fonts are handled in the svelte code for Core, so that the Core elements will inherit fonts from the Hugo theme rather than specifying their own. (When developing, the svelte app does have its own font styles, but these are not copied into the Hugo content when the build script is run.)

For the `dora` theme, Core inherits that theme's "Google Sans [classic]" font; for `dora-2025`, it inherits the newer "Google Sans Flex". They don't really look any different, but they have slightly different optical rendering, and that's what was causing the problem reported in #963.

Fix #963