### PR TITLE
Adjust header search bar to match 2025 styles 

### DIFF
--- a/hugo/themes/dora-2025/assets/scss/footer.scss
+++ b/hugo/themes/dora-2025/assets/scss/footer.scss
@@ -52,7 +52,7 @@ footer {
       input {
         box-sizing: border-box;
         background: url("/img/icon-search.svg") no-repeat 12px center;
-        background-color: var(--grey-10);
+        background-color: var(--dora-primary-light);
         border: none;
         padding: 12px 12px 12px 48px;
         border-radius: 50vh;

--- a/hugo/themes/dora-2025/assets/scss/search-input.scss
+++ b/hugo/themes/dora-2025/assets/scss/search-input.scss
@@ -8,8 +8,13 @@
     flex-grow: 1;
     margin: 0;
     padding-inline: 1rem;
-    border: 1px solid #999;
+    background-color: var(--dora-primary-light);
+    border-color: var(--dora-primary-dark);
+    outline:none;
     border-radius: 10vmin 0 0 10vmin;
+    &::placeholder {
+      color: var(--grey-70);
+    }
 }
 
 .searchButton {
@@ -18,4 +23,6 @@
     margin: 0  !important;
     border-radius: 0 10vmin 10vmin 0  !important;
     font-size: 1rem  !important;
+    background-color:var(--dora-primary-dark) !important;
+    color:var(--dora-primary-light) !important;
 }


### PR DESCRIPTION
Apply 2025-era styles to the search bar in the header

Preview from local:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/126244e6-ac4d-4417-a243-e73df569479e" />


Fixes #965