### PR TITLE
Mobile and misc styles for dora-2025

### DIFF
--- a/hugo/themes/dora-2025/assets/scss/footer.scss
+++ b/hugo/themes/dora-2025/assets/scss/footer.scss
@@ -52,7 +52,7 @@ footer {
       input {
         box-sizing: border-box;
         background: url("/img/icon-search.svg") no-repeat 12px center;
-        background-color: var(--grey-10);
+        background-color: var(--dora-primary-light);
         border: none;
         padding: 12px 12px 12px 48px;
         border-radius: 50vh;

--- a/hugo/themes/dora-2025/assets/scss/forms.scss
+++ b/hugo/themes/dora-2025/assets/scss/forms.scss
@@ -68,17 +68,17 @@ input[type="submit"],
   }
 }
 
-button.secondary,
-.button.secondary {
-  background-color: $color-text-knockout;
-  color: $color-text-highlight;
-  border: 1px solid $border-light;
+// button.secondary,
+// .button.secondary {
+//   background-color: $color-text-knockout;
+//   color: $color-text-highlight;
+//   border: 1px solid $border-light;
 
-  &:hover {
-    color: $color-text-highlight;
-    background-color: $background-soft;
-  }
-}
+//   &:hover {
+//     color: $color-text-highlight;
+//     background-color: $background-soft;
+//   }
+// }
 
 ::placeholder {
   font-weight: 200;

--- a/hugo/themes/dora-2025/assets/scss/forms.scss
+++ b/hugo/themes/dora-2025/assets/scss/forms.scss
@@ -46,6 +46,11 @@ input[type="submit"],
   cursor: pointer;
   text-decoration: none;
 
+  @include media-small {
+    font-size: 18px;
+    padding: 10px 16px;
+  }
+
   &:disabled {
     border-color: var(--grey-50);
     color: var(--grey-50);

--- a/hugo/themes/dora-2025/assets/scss/guides.scss
+++ b/hugo/themes/dora-2025/assets/scss/guides.scss
@@ -34,7 +34,6 @@ img {
   .guides-header {
     h2 {
       color: $color-text-medium;
-      font-size: 1.75rem;
     }
     margin-bottom: 0.5em;
   }

--- a/hugo/themes/dora-2025/assets/scss/headings.scss
+++ b/hugo/themes/dora-2025/assets/scss/headings.scss
@@ -19,6 +19,7 @@
     line-height: 120%;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
+    text-wrap: balance;
 }
 
 h1 {

--- a/hugo/themes/dora-2025/assets/scss/homepage.scss
+++ b/hugo/themes/dora-2025/assets/scss/homepage.scss
@@ -47,7 +47,7 @@
   background-color: var(--dora-primary-light);
   .lede-content-container {
     max-width: $layout-breakpoint-maxplus;
-    margin: 48px auto;
+    margin: calc(min(48px, 8vw)) auto;
     .lede-content {
       margin: 12px 36px;
       max-width: 100%;
@@ -74,7 +74,7 @@
 
       p {
         font-family: $font-google-sans;
-        font-size: calc(clamp(10px, 2.5vw, 20px));
+        font-size: calc(clamp(16px, 2.5vw, 20px));
         font-weight: 500;
       }
     }
@@ -185,7 +185,7 @@
       @include media-large {
         grid-template-columns: 1fr 1fr;
       }
-      @include media-small {
+      @include media-medium {
         grid-template-columns: 1fr;
       }
 

--- a/hugo/themes/dora-2025/assets/scss/homepage.scss
+++ b/hugo/themes/dora-2025/assets/scss/homepage.scss
@@ -100,8 +100,12 @@
       h3 {
         font-size: 12px;
         text-transform: uppercase;
-        font-weight: 300;
+        font-weight: 500;
         letter-spacing: 1px;
+
+        @include media-small {
+          font-size:11px;
+        }
       }
 
       p {

--- a/hugo/themes/dora-2025/assets/scss/homepage.scss
+++ b/hugo/themes/dora-2025/assets/scss/homepage.scss
@@ -36,10 +36,14 @@
   div.hero-link {
     text-align: right;
     margin-right: 24px;
+    @include media-medium {
+      display:none;
+    }
   }
 }
 
 .homepage-lede {
+  box-sizing: border-box;
   background-color: var(--dora-primary-light);
   .lede-content-container {
     max-width: $layout-breakpoint-maxplus;
@@ -51,6 +55,11 @@
       display: flex;
       flex-direction: row;
       align-items: center;
+
+      @include media-medium {
+        flex-direction: column;
+      }
+
       h1,
       p {
         flex: 1 0 50%;
@@ -58,13 +67,14 @@
       }
 
       h1 {
-        font-size: 72px;
+        font-size: calc(min(72px, 7vw));
         font-weight: 600;
+        padding-right: 12px;
       }
 
       p {
         font-family: $font-google-sans;
-        font-size: 20px;
+        font-size: calc(clamp(10px, 2.5vw, 20px));
         font-weight: 500;
       }
     }
@@ -140,6 +150,20 @@
         }
       }
     }
+
+    @include media-medium {
+      flex-direction: column-reverse;
+
+      &.image-align-right , &.image-align-left {
+        flex-direction: column-reverse;
+      }
+
+      .image {
+        text-align: center;
+        margin-bottom: 24px;
+      }
+
+    }
   }
 }
 
@@ -157,6 +181,13 @@
       display: grid;
       gap: 24px;
       grid-template-columns: 1fr 1fr 1fr 1fr;
+
+      @include media-large {
+        grid-template-columns: 1fr 1fr;
+      }
+      @include media-small {
+        grid-template-columns: 1fr;
+      }
 
       .homepage-snipe {
         background-color: var(--grey-50);

--- a/hugo/themes/dora-2025/assets/scss/main.scss
+++ b/hugo/themes/dora-2025/assets/scss/main.scss
@@ -61,12 +61,14 @@ body {
 
     @include media-medium {
       padding: 0.75em;
-      width: auto;
+      width:100%;
+      margin:0;
     }
 
     @include media-small {
       padding: 0.5em;
-      width: auto;
+      width:100%;
+      margin:0;
     }
   }
 }
@@ -152,7 +154,7 @@ section.banner {
       padding: 1em 0.5em;
       margin: auto 0;
       h1 {
-        font-size: 72px;
+        font-size: calc(min(72px,12vw));
         font-weight: 600;
       }
 
@@ -160,7 +162,7 @@ section.banner {
         font-family: $font-google-sans;
         line-height: 1.35;
         font-weight: 500;
-        font-size: 16px;
+        font-size: calc(clamp(12px, 5vw, 16px));
       }
     }
 

--- a/hugo/themes/dora-2025/assets/scss/nav.scss
+++ b/hugo/themes/dora-2025/assets/scss/nav.scss
@@ -1,3 +1,84 @@
+// the following styles control the show/hide of the mobile menu.
+// They're listed out here because the mobile menu exists
+// outside of the regular nav.
+
+#hamburgerContainer {
+  display: none;
+  @include media-medium {
+    display: block;
+  }
+
+  #hamburgerIcon {
+    display: block;
+    font-size: 36px;
+    height: 48px;
+    width: 48px;
+    line-height: 48px;
+    text-align: center;
+
+    .menu {
+      display: block;
+    }
+
+    .close {
+      display: none;
+    }
+  }
+
+  input[type="checkbox"] {
+    display: none;
+  }
+}
+
+.menuLinksMobile {
+  height: 0;
+  overflow: hidden;
+
+  ul {
+    margin: 0;
+    margin-block-start: 0.5em;
+    padding-inline-start: 0;
+    li {
+      list-style-type: none;
+      padding: 0.5em 1em;
+      margin: 0;
+      border-bottom: 1px solid var(--grey-40);
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      a {
+        text-decoration: none;
+        color: var(--grey-70);
+        white-space: nowrap;
+        font-weight: 500;
+        font-size: 1em;
+        line-height: 1em;
+
+        .open_in_new {
+          font-size: 1.25em;
+        }
+      }
+    }
+  }
+}
+
+body:has(#mobileMenuController:checked) {
+  .menuLinksMobile {
+    height: fit-content;
+    padding: 0 18px 12px 18px;
+  }
+  #hamburgerContainer {
+    #hamburgerIcon .close {
+      display: block;
+    }
+    #hamburgerIcon .menu {
+      display: none;
+    }
+  }
+}
+
 header {
   position: sticky;
   top: 0;
@@ -6,10 +87,9 @@ header {
   box-shadow: 0 0 6px color-mix(in srgb, var(--dora-primary-dark), transparent 70%);
 
   @include media-small {
-    position:relative;
+    position: relative;
   }
 
-  
   .navContainer {
     div.dora-logo-link a {
       display: block;
@@ -22,16 +102,22 @@ header {
       margin-right: 16px;
       font-size: 0.9em;
 
-      ul {
+      ul.menuLinksDesktop {
         display: flex;
+        align-items: center;
         margin: 0;
         li {
           list-style-type: none;
           padding: 0 1em;
 
+          @include media-large {
+            font-size:.85em;
+            padding: 0 .7em;
+          }
+
           a {
             text-decoration: none;
-            color: hsl(208, 5%, 45%);
+            color: var(--grey-70);
             white-space: nowrap;
             font-weight: 500;
             font-size: 1em;
@@ -40,7 +126,7 @@ header {
             text-decoration: underline solid white;
 
             .open_in_new {
-              font-size:1em;
+              font-size: 1em;
             }
           }
 
@@ -56,11 +142,6 @@ header {
             text-underline-offset: 0.5em;
           }
         }
-
-        li#searchLinkMobile {
-          // if full menu shown, don't show mobile search link
-          display: none;
-        }
       }
     }
     #searchIcon {
@@ -68,118 +149,13 @@ header {
     }
   }
 
-  // hamburger menu for mobile
-  .navContainer > nav > label > input[type="checkbox"] {
-    display: none;
-  }
-
-  @include media-large {
-    $mobile-menu-width: 180px;
-
-    .navContainer nav label {
-      ul {
-        position: absolute;
-        top: 64px;
-        right: 0px;
-        visibility: hidden;
-        opacity: 0;
-        width: $mobile-menu-width;
-        height: calc(100% - 64px);
-        display: block;
-        opacity: 0;
-        padding: 0;
-        z-index: 300;
-
-        li {
-          padding: 24px 4px 24px 24px;
-          border-bottom: 1px solid #dadce0;
-          background-color: var(--background);
+  @include media-medium {
+    .navContainer {
+      nav {
+        ul.menuLinksDesktop {
+          display: none;
         }
       }
-    }
-
-    label .menu {
-      position: absolute;
-      top: 0;
-      right: 0;
-      transition: 0.5s ease-in-out;
-      cursor: pointer;
-    }
-
-    label .hamburger {
-      position: absolute;
-      top: 32px;
-      left: 16px;
-      width: 32px;
-      height: 2px;
-      background: rgb(95, 99, 104);
-      display: block;
-      transform-origin: center;
-      transition: 0.5s ease-in-out;
-    }
-
-    label .hamburger:after,
-    label .hamburger:before {
-      transition: 0.35s ease-in-out;
-      content: "";
-      position: absolute;
-      display: block;
-      width: 100%;
-      height: 100%;
-      background: rgb(95, 99, 104);
-    }
-
-    label .hamburger:before {
-      top: -10px;
-    }
-
-    label .hamburger:after {
-      bottom: -10px;
-    }
-
-    label input:checked + .menu .hamburger {
-      transform: rotate(45deg);
-    }
-
-    label input:checked + .menu .hamburger:after {
-      transform: rotate(90deg);
-      bottom: 0;
-    }
-
-    label input:checked + .menu .hamburger:before {
-      transform: rotate(90deg);
-      top: 0;
-    }
-
-    label input:checked + .menu + ul {
-      opacity: 1;
-      transition: 0.25s ease;
-      visibility: visible;
-    }
-
-    .page-overlay {
-      transition: 0.35s ease;
-      background-color: rgba(0, 0, 0, 0);
-      position: absolute;
-      top: 64px;
-      left: 0;
-      width: 100%;
-      bottom: 0;
-      z-index: 100;
-      visibility: hidden;
-    }
-
-    label input:checked + .menu + ul + .page-overlay {
-      background-color: rgba(0, 0, 0, 0.4);
-      visibility: visible;
-    }
-
-    #searchLinkMobile {
-      // if full menu hidden, search is a regular menu item
-      display: block !important;
-    }
-    #searchLinkDesktop {
-      display: none;
     }
   }
 
@@ -221,7 +197,6 @@ header {
     }
   }
 }
-
 
 .site-banner {
   background-color: var(--dora-primary-dark);

--- a/hugo/themes/dora-2025/assets/scss/nav.scss
+++ b/hugo/themes/dora-2025/assets/scss/nav.scss
@@ -3,7 +3,12 @@ header {
   top: 0;
   background-color: var(--background);
   z-index: 999;
-  border-bottom: 4px solid var(--dora-primary-dark); 
+  box-shadow: 0 0 6px color-mix(in srgb, var(--dora-primary-dark), transparent 70%);
+
+  @include media-small {
+    position:relative;
+  }
+
   
   .navContainer {
     div.dora-logo-link a {

--- a/hugo/themes/dora-2025/assets/scss/normalize.scss
+++ b/hugo/themes/dora-2025/assets/scss/normalize.scss
@@ -1,4 +1,5 @@
-/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+/* DORA normalize styles */
+/*! adapted from normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
 /* Document
    ========================================================================== */
@@ -9,8 +10,8 @@
  */
 
 html {
-    line-height: 1.5; /* 1 */
-    -webkit-text-size-adjust: 100%; /* 2 */
+  line-height: 1.5; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections
@@ -21,7 +22,7 @@ html {
    */
 
 body {
-    margin: 0;
+  margin: 0;
 }
 
 /**
@@ -29,7 +30,8 @@ body {
    */
 
 main {
-    display: block;
+  display: block;
+  box-sizing: border-box; // added to base normalize.css
 }
 
 /**
@@ -38,8 +40,8 @@ main {
    */
 
 h1 {
-    font-size: 2em;
-    margin: 0.67em 0;
+  font-size: 2em;
+  margin: 0.67em 0;
 }
 
 /* Grouping content
@@ -51,9 +53,9 @@ h1 {
    */
 
 hr {
-    box-sizing: content-box; /* 1 */
-    height: 0; /* 1 */
-    overflow: visible; /* 2 */
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
 }
 
 /**
@@ -62,8 +64,8 @@ hr {
    */
 
 pre {
-    font-family: monospace, monospace; /* 1 */
-    font-size: 1em; /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /* Text-level semantics
@@ -74,7 +76,7 @@ pre {
    */
 
 a {
-    background-color: transparent;
+  background-color: transparent;
 }
 
 /**
@@ -83,9 +85,9 @@ a {
    */
 
 abbr[title] {
-    border-bottom: none; /* 1 */
-    text-decoration: underline; /* 2 */
-    text-decoration: underline dotted; /* 2 */
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
 }
 
 /**
@@ -94,7 +96,7 @@ abbr[title] {
 
 b,
 strong {
-    font-weight: bolder;
+  font-weight: bolder;
 }
 
 /**
@@ -105,16 +107,17 @@ strong {
 code,
 kbd,
 samp {
-    font-family: monospace, monospace; /* 1 */
-    font-size: 1em; /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /**
    * Add the correct font size in all browsers.
    */
 
-small, .small {
-    font-size: 80%;
+small,
+.small {
+  font-size: 80%;
 }
 
 /**
@@ -124,18 +127,18 @@ small, .small {
 
 sub,
 sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
 }
 
 sub {
-    bottom: -0.25em;
+  bottom: -0.25em;
 }
 
 sup {
-    top: -0.5em;
+  top: -0.5em;
 }
 
 /* Embedded content
@@ -146,7 +149,7 @@ sup {
    */
 
 img {
-    border-style: none;
+  border-style: none;
 }
 
 /* Forms
@@ -162,10 +165,10 @@ input,
 optgroup,
 select,
 textarea {
-    font-family: inherit; /* 1 */
-    font-size: 100%; /* 1 */
-    line-height: 1.15; /* 1 */
-    margin: 0; /* 2 */
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**
@@ -175,8 +178,8 @@ textarea {
 
 button,
 input {
-    /* 1 */
-    overflow: visible;
+  /* 1 */
+  overflow: visible;
 }
 
 /**
@@ -186,8 +189,8 @@ input {
 
 button,
 select {
-    /* 1 */
-    text-transform: none;
+  /* 1 */
+  text-transform: none;
 }
 
 /**
@@ -198,7 +201,7 @@ button,
 [type="button"],
 [type="reset"],
 [type="submit"] {
-    -webkit-appearance: button;
+  -webkit-appearance: button;
 }
 
 /**
@@ -209,8 +212,8 @@ button::-moz-focus-inner,
 [type="button"]::-moz-focus-inner,
 [type="reset"]::-moz-focus-inner,
 [type="submit"]::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
+  border-style: none;
+  padding: 0;
 }
 
 /**
@@ -221,7 +224,7 @@ button:-moz-focusring,
 [type="button"]:-moz-focusring,
 [type="reset"]:-moz-focusring,
 [type="submit"]:-moz-focusring {
-    outline: 1px dotted ButtonText;
+  outline: 1px dotted ButtonText;
 }
 
 /**
@@ -229,7 +232,7 @@ button:-moz-focusring,
    */
 
 fieldset {
-    padding: 0.35em 0.75em 0.625em;
+  padding: 0.35em 0.75em 0.625em;
 }
 
 /**
@@ -240,12 +243,12 @@ fieldset {
    */
 
 legend {
-    box-sizing: border-box; /* 1 */
-    color: inherit; /* 2 */
-    display: table; /* 1 */
-    max-width: 100%; /* 1 */
-    padding: 0; /* 3 */
-    white-space: normal; /* 1 */
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
 }
 
 /**
@@ -253,7 +256,7 @@ legend {
    */
 
 progress {
-    vertical-align: baseline;
+  vertical-align: baseline;
 }
 
 /**
@@ -261,7 +264,7 @@ progress {
    */
 
 textarea {
-    overflow: auto;
+  overflow: auto;
 }
 
 /**
@@ -271,8 +274,8 @@ textarea {
 
 [type="checkbox"],
 [type="radio"] {
-    box-sizing: border-box; /* 1 */
-    padding: 0; /* 2 */
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
 }
 
 /**
@@ -281,7 +284,7 @@ textarea {
 
 [type="number"]::-webkit-inner-spin-button,
 [type="number"]::-webkit-outer-spin-button {
-    height: auto;
+  height: auto;
 }
 
 /**
@@ -290,8 +293,8 @@ textarea {
    */
 
 [type="search"] {
-    -webkit-appearance: textfield; /* 1 */
-    outline-offset: -2px; /* 2 */
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**
@@ -299,7 +302,7 @@ textarea {
    */
 
 [type="search"]::-webkit-search-decoration {
-    -webkit-appearance: none;
+  -webkit-appearance: none;
 }
 
 /**
@@ -308,8 +311,8 @@ textarea {
    */
 
 ::-webkit-file-upload-button {
-    -webkit-appearance: button; /* 1 */
-    font: inherit; /* 2 */
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /* Interactive
@@ -320,7 +323,7 @@ textarea {
    */
 
 details {
-    display: block;
+  display: block;
 }
 
 /*
@@ -328,7 +331,7 @@ details {
    */
 
 summary {
-    display: list-item;
+  display: list-item;
 }
 
 /* Misc
@@ -339,7 +342,7 @@ summary {
    */
 
 template {
-    display: none;
+  display: none;
 }
 
 /**
@@ -347,5 +350,5 @@ template {
    */
 
 [hidden] {
-    display: none;
+  display: none;
 }

--- a/hugo/themes/dora-2025/assets/scss/search-input.scss
+++ b/hugo/themes/dora-2025/assets/scss/search-input.scss
@@ -8,8 +8,13 @@
     flex-grow: 1;
     margin: 0;
     padding-inline: 1rem;
-    border: 1px solid #999;
+    background-color: var(--dora-primary-light);
+    border-color: var(--dora-primary-dark);
+    outline:none;
     border-radius: 10vmin 0 0 10vmin;
+    &::placeholder {
+      color: var(--grey-70);
+    }
 }
 
 .searchButton {
@@ -18,4 +23,6 @@
     margin: 0  !important;
     border-radius: 0 10vmin 10vmin 0  !important;
     font-size: 1rem  !important;
+    background-color:var(--dora-primary-dark) !important;
+    color:var(--dora-primary-light) !important;
 }

--- a/hugo/themes/dora-2025/layouts/partials/header.html
+++ b/hugo/themes/dora-2025/layouts/partials/header.html
@@ -19,6 +19,12 @@
         <li><a href="https://dora.community/" target="_blank">Community&nbsp;&nbsp;<span
               class="google-material-icons open_in_new">open_in_new</span></a></li>
       </ul>
+      <div id="searchInputPopover" popover>
+        <div id="searchInputPopoverFields">
+          {{- partial "search_input" -}}
+        </div>
+      </div>
+      <div class="page-overlay"></div>
       <label id="hamburgerContainer">
         <input type="checkbox" id="mobileMenuController" onchange="console.log(this.checked)" />
         <span class="google-material-icons" aria-label="menu" id="hamburgerIcon">
@@ -45,13 +51,6 @@
           class="google-material-icons open_in_new">open_in_new</span></a></li>
   </ul>
 </div>
-
-<div id="searchInputPopover" popover>
-  <div id="searchInputPopoverFields">
-    {{- partial "search_input" -}}
-  </div>
-</div>
-<div class="page-overlay"></div>
 
 <script>
   document.querySelector('#searchIcon').addEventListener('click', (e) => {

--- a/hugo/themes/dora-2025/layouts/partials/header.html
+++ b/hugo/themes/dora-2025/layouts/partials/header.html
@@ -4,43 +4,64 @@
       <a href="/"><img src="/img/dora-logo.svg" height="48px" class="dora-logo" alt="DORA"></a>
     </div>
     <nav>
-      <label>
-        <input type="checkbox">
-        <span class="menu"><span class="hamburger"></span></span>
-        <ul id="menuLinks">
-          <li><a href="/publications/" {{ if (eq .Section "publications" ) }}class="active" {{ end }}>Publications</a>
-          </li>
-          <li><a href="/research/" {{ if (eq .Section "research" ) }}class="active" {{ end }}>Research</a></li>
-          <li><a href="/capabilities/" {{ if (eq .Section "capabilities" ) }}class="active" {{ end }}>Capabilities</a>
-          </li>
-          <li><a href="/guides/" {{ if (eq .Section "guides" ) }}class="active" {{ end }}>Guides</a></li>
-          <li><a href="/quickcheck/" {{ if (eq .Section "quickcheck" ) }}class="active" {{ end }}>Quick Check</a>
-          </li>
-          <li id="searchLinkDesktop"><a class="google-material-icons" id="searchIcon"
-              aria-label="Search dora.dev">search</a></li>
-          <li id="searchLinkMobile"><a href="/search/" {{ if (eq .Section "search" ) }}class="active" {{ end
-              }}>Search</a>
-          </li>
-          <li><a href="https://dora.community/" target="_blank">Community&nbsp;&nbsp;<span
-                class="google-material-icons open_in_new">open_in_new</span></a></li>
-        </ul>
-        <div id="searchInputPopover" popover>
-          <div id="searchInputPopoverFields">
-            {{- partial "search_input" -}}
-          </div>
-        </div>
-        <div class="page-overlay"></div>
+      <ul class="menuLinksDesktop">
+        <li><a href="/publications/" {{ if (eq .Section "publications" ) }}class="active" {{ end }}>Publications</a>
+        </li>
+        <li><a href="/research/" {{ if (eq .Section "research" ) }}class="active" {{ end }}>Research</a></li>
+        <li><a href="/capabilities/" {{ if (eq .Section "capabilities" ) }}class="active" {{ end }}>Capabilities</a>
+        </li>
+        <li><a href="/guides/" {{ if (eq .Section "guides" ) }}class="active" {{ end }}>Guides</a></li>
+        <li><a href="/quickcheck/" {{ if (eq .Section "quickcheck" ) }}class="active" {{ end }}>Quick Check</a>
+        </li>
+        <li id="searchLinkDesktop"><a class="google-material-icons" id="searchIcon"
+            aria-label="Search dora.dev">search</a></li>
+        </li>
+        <li><a href="https://dora.community/" target="_blank">Community&nbsp;&nbsp;<span
+              class="google-material-icons open_in_new">open_in_new</span></a></li>
+      </ul>
+      <label id="hamburgerContainer">
+        <input type="checkbox" id="mobileMenuController" onchange="console.log(this.checked)" />
+        <span class="google-material-icons" aria-label="menu" id="hamburgerIcon">
+          <span class="menu">menu</span>
+          <span class="close">close</span>
+        </span>
       </label>
     </nav>
-    <script>
-      document.querySelector('#searchIcon').addEventListener('click', (e) => {
-        e.preventDefault();
-        document.querySelector('#searchInputPopover').showPopover();
-        document.querySelector('#searchInputPopover .searchQuery').focus();
-      })
-    </script>
   </div>
 </header>
+<div class="menuLinksMobile">
+  <ul>
+    <li><a href="/publications/" {{ if (eq .Section "publications" ) }}class="active" {{ end }}>Publications</a>
+    </li>
+    <li><a href="/research/" {{ if (eq .Section "research" ) }}class="active" {{ end }}>Research</a></li>
+    <li><a href="/capabilities/" {{ if (eq .Section "capabilities" ) }}class="active" {{ end }}>Capabilities</a>
+    </li>
+    <li><a href="/guides/" {{ if (eq .Section "guides" ) }}class="active" {{ end }}>Guides</a></li>
+    <li><a href="/quickcheck/" {{ if (eq .Section "quickcheck" ) }}class="active" {{ end }}>Quick Check</a>
+    </li>
+    <li id="searchLinkMobile"><a href="/search/" {{ if (eq .Section "search" ) }}class="active" {{ end }}>Search</a>
+    </li>
+    <li><a href="https://dora.community/" target="_blank">Community&nbsp;&nbsp;<span
+          class="google-material-icons open_in_new">open_in_new</span></a></li>
+  </ul>
+</div>
+
+<div id="searchInputPopover" popover>
+  <div id="searchInputPopoverFields">
+    {{- partial "search_input" -}}
+  </div>
+</div>
+<div class="page-overlay"></div>
+
+<script>
+  document.querySelector('#searchIcon').addEventListener('click', (e) => {
+    e.preventDefault();
+    document.querySelector('#searchInputPopover').showPopover();
+    document.querySelector('#searchInputPopover .searchQuery').focus();
+  })
+</script>
+
+
 {{ if not .Params.hideSiteBanner }}
-  {{- partial "site_banner" . -}}
+{{- partial "site_banner" . -}}
 {{ end }}


### PR DESCRIPTION
This PR adds responsive/mobile styles, with a focus on portrait-mode phone screen sizes. _Tablets and landscapes work too; it's fully responsive, but some of those might not be quite as elegant; per Google analytics, our traffic is 87.3% desktop, 12.2% mobile, and 0.2% tablet [most of which is probably me; I'm an iPad guy])._

It also uses a simplified implementation of the mobile menu. IMHO, it looks better, and it will be more maintainable. I removed the slinky animation that transforms the hamburger menu into an X and back, but that was always kind of gimmicky.

There should be no effect on prod (or in the preview); here's what it looks like (with mobile emulation) on my local:
![localhost_1313_(iPhone SE)](https://github.com/user-attachments/assets/5cbdc4b8-06e1-4164-badc-09e8954840d3)

Fixes #965 
Fixes #964  
Fixes #973 