### PR TITLE
Allow wider page for Core diagram

### DIFF
--- a/hugo/themes/dora-2025/assets/scss/research.scss
+++ b/hugo/themes/dora-2025/assets/scss/research.scss
@@ -79,6 +79,11 @@ h3 {
     }
 }
 
+// Wider page allows room for Core diagram
+main:has(#app) {
+  max-width:1200px;
+}
+
 tab_links {
     display:block;
     width:100%;

--- a/hugo/themes/dora-2025/assets/scss/research.scss
+++ b/hugo/themes/dora-2025/assets/scss/research.scss
@@ -81,7 +81,7 @@ h3 {
 
 // Wider page allows room for Core diagram
 main:has(#app) {
-  max-width:1200px;
+  padding:0;
 }
 
 tab_links {


### PR DESCRIPTION
This PR removes padding from `main` to allow room for the Core model (this was a regression due to the switch from `dora` theme to `dora-2025`).

Preview: https://doradotdev--pr986-drafts-on-8xmihi1u.web.app/research/?view=detail

Fixes #984


(Note that this still doesn't solve for narrow viewports; we still need to do something for #683)