### PR TITLE
Remove last instance of expanded DORA acronym

### DIFF
--- a/hugo/content/capabilities/continuous-integration/index.md
+++ b/hugo/content/capabilities/continuous-integration/index.md
@@ -31,9 +31,8 @@ into the
 [main version of the code base](/capabilities/trunk-based-development)
 (known as
 [*trunk*](/capabilities/trunk-based-development),
-*main*, or *mainline*) on a regular basis. DevOps Research and Assessment
-(DORA)
-[research](/research/2015/2015-state-of-devops-report.pdf#page=20)
+*main*, or *mainline*) on a regular basis. The [2015 State of DevOps
+Report](/research/2015/2015-state-of-devops-report.pdf#page=20)
 (PDF) shows that teams perform better when developers merge their work into
 trunk at least daily. A set of automated tests is run both before and after the
 merge in order to validate that the changes don't introduce regression bugs. If


### PR DESCRIPTION
Well, the second to the last as it's also on the press release announcing the acquisition by Google Cloud but it's appropriate to keep that one.

Preview: https://doradotdev--pr989-drafts-off-f8hsoyjj.web.app/capabilities/continuous-integration/