### PR TITLE
Update sponsor resource center and brand guidelines for 2025

### DIFF
--- a/hugo/content/brand-guidelines/_index.md
+++ b/hugo/content/brand-guidelines/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "DORA Brand Guidelines"
 date: 2024-10-01T20:58:12-04:00
-updated: 2024-10-21
+updated: 2025-04-16
 draft: false
 bannerTitle: DORA Brand Guidelines
 layout: single
@@ -9,7 +9,7 @@ layout: single
 
 ![DORA](DORA-Horizontal-Logo.svg)
 
-DORA is in the process of rebranding it's look and feel. The new brand will be used in the 2024 DORA Report and will roll out across the rest of the DORA properties in the coming months.
+DORA's current brand was launched in October of 2024 along with the [2024 DORA Report](/research/2024/dora-report/). As part of this rebranding, we have also "de-acronymed" DORA. DORA is the brand name and it is not an acronym for anything, it should always be written in CAPITAL LETTERS. "DORA" is correct, other casing, such as "Dora" or "dora" are incorrect and should not be used.
 
 ## Branding Guidelines
 
@@ -21,8 +21,14 @@ Please refer to our [brand guidelines](https://storage.googleapis.com/dora-brand
 
 * [DORA Community Logos](https://storage.googleapis.com/dora-brand-2024/DORA-Community-Logo.zip) <small>(ZIP, 4.9MB)</small>
 
-## 2024 DORA Report Graphics
+## Impact of Generative AI on Software Development report graphics
 
-* [DORA Report Graphics](https://storage.googleapis.com/dora-report-2024/DORA-report-cover-art.zip) <small>(ZIP, 271KB)</small>
+* [Impact of Generative AI on Software Development report graphics](https://storage.googleapis.com/dora-report-gen-ai-2025/impact-of-generative-ai-in-software-development-report-cover-art.zip) <small>(ZIP, 398KB)</small>
+
+<a href="https://storage.googleapis.com/dora-report-gen-ai-2025/impact-of-generative-ai-in-software-development-report-cover-art.zip"><img src="/research/ai/gen-ai-report/dora-impact-of-generative-ai-in-software-development-report.png" style="max-width:24em;"></a>
+
+## 2024 DORA Report graphics
+
+* [2024 DORA Report graphics](https://storage.googleapis.com/dora-report-2024/DORA-report-cover-art.zip) <small>(ZIP, 271KB)</small>
 
 <a href="https://storage.googleapis.com/dora-report-2024/DORA-report-cover-art.zip"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" style="max-width:24em;"></a>

--- a/hugo/content/sponsors/resource-center/index.md
+++ b/hugo/content/sponsors/resource-center/index.md
@@ -3,17 +3,17 @@ title: "DORA Sponsor Resource Center"
 date: 2024-06-23T20:58:12-04:00
 draft: false
 bannerTitle: DORA Sponsor Resource Center
-bannerSubtitle: Thank you for sponsoring the 2024 DORA Report
+bannerSubtitle: Thank you for sponsoring the 2025 DORA Report
 ---
 
-Thank you for your support of the 2024 DORA Report. We appreciate your commitment to helping us understand the state of software delivery performance and identify the practices and capabilities that drive success.
+Thank you for your support of the 2025 DORA Report. We appreciate your commitment to helping us understand the state of software delivery performance and identify the practices and capabilities that drive success.
 
 ## Graphics
 
 The [DORA Brand Guidelines](/brand-guidelines/) include graphics that can be used in promotional materials.
 
 ## Sponsor distribution list
-Announcements and updates will be sent to the `dora-sponsors-2024@` distribution list.  Reach out to [sponsor-dora@google.com](mailto:sponsor-dora@google.com) with the names and email addresses of anyone else from your organization who should be added to this distribution list.
+Announcements and updates will be sent to the `dora-sponsors-2025@` distribution list.  Reach out to [sponsor-dora@google.com](mailto:sponsor-dora@google.com) with the names and email addresses of anyone else from your organization who should be added to this distribution list.
 
 ## Contact us
 What questions do you have? What additional ideas do you have for collaboration this year?  Contact us at [sponsor-dora@google.com](mailto:sponsor-dora@google.com).

--- a/test/playwright/tests/brand-guidelines/dora-brand-guidelines.spec.ts
+++ b/test/playwright/tests/brand-guidelines/dora-brand-guidelines.spec.ts
@@ -5,7 +5,8 @@ import { test, expect } from '@playwright/test';
 export const pageHeaders = [
   'Branding Guidelines',
   'Graphics',
-  '2024 DORA Report Graphics'
+  'Impact of Generative AI on Software Development report graphics',
+  '2024 DORA Report graphics'
 ];
 
 test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
* Updates the sponsor resource center for 2025
* Adds the graphics for the Gen AI report to the brand guidelines page
* Notes that DORA is no longer an acronym on the brand guidelines page

Preview URLs:
* https://doradotdev--pr991-drafts-off-ptlcvie4.web.app/sponsors/resource-center/
* https://doradotdev--pr991-drafts-off-ptlcvie4.web.app/brand-guidelines/