### PR TITLE
Add more 2025 survey logos

### DIFF
--- a/hugo/content/brand-guidelines/_index.md
+++ b/hugo/content/brand-guidelines/_index.md
@@ -21,7 +21,7 @@ Please refer to our [brand guidelines](https://storage.googleapis.com/dora-brand
 
 * [DORA Community Logos](https://storage.googleapis.com/dora-brand-2024/DORA-Community-Logo.zip) <small>(ZIP, 4.9MB)</small>
 
-* [DORA Survey Logos](https://storage.googleapis.com/dora-sponsor-resources/DORA-survey-graphics-2025.zip) <small>(ZIP, 249KB)</small>
+* [DORA Survey Logos](https://storage.googleapis.com/dora-sponsor-resources/DORA-survey-graphics-2025.zip) <small>(ZIP, 1.1MB)</small>
 
 ## Impact of Generative AI on Software Development report graphics
 


### PR DESCRIPTION
Trivial change that updates the size of the zip file.

Preview URL: https://doradotdev--pr1007-drafts-off-8sxlyy1n.web.app/brand-guidelines/

Should show the DORA Survey Logos file is `1.1MB` which should match the file size if you download it.

