### PR TITLE
Link the survey discussion guide to conversations.dora.dev

### DIFF
--- a/hugo/content/survey/discussion-guide/index.md
+++ b/hugo/content/survey/discussion-guide/index.md
@@ -45,7 +45,7 @@ Remind everyone that the goal of this discussion isn't to share their specific a
 
 ## Suggested discussion questions (40 minutes)
 
-Use the questions below as potential discussion questions with the group. You may not have time to get through all of them. Give the group time to share lots of perspectives and insights.
+Use the questions below as potential discussion questions with the group. You may not have time to get through all of them. Give the group time to share lots of perspectives and insights. Alternatively, use [conversations.dora.dev/survey](https://conversations.dora.dev/survey) as a guide through the discussion questions.
 
 Pick a selection of the eight questions listed below that you would like to discuss as a group. We strongly recommend that you use at least these two:
 


### PR DESCRIPTION
Preview: https://doradotdev--pr1014-drafts-off-2lzimdfj.web.app/survey/discussion-guide/ now includes a link to https://conversations.dora.dev/survey.

Look for it in [this section](https://doradotdev--pr1014-drafts-off-2lzimdfj.web.app/survey/discussion-guide/#suggested-discussion-questions-40-minutes).