### PR TITLE
New tab styling -- DORA 2025

### DIFF
--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
       ./svelte/core-v2/build-core.sh
 
       # install hugo "extended"
-      HUGO_VERSION=0.114.1
+      HUGO_VERSION=0.147.9
       wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb -O /tmp/hugo.deb
 
       apt install /tmp/hugo.deb

--- a/ci/preview-content.cloudbuild.yaml
+++ b/ci/preview-content.cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
       ./svelte/core-v2/build-core.sh
 
       # install hugo "extended"
-      HUGO_VERSION=0.114.1
+      HUGO_VERSION=0.147.9
       wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb -O /tmp/hugo.deb
 
       apt install /tmp/hugo.deb

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ## Hugo
 The following development with Hugo will be sufficient for most of the DORA.dev website development efforts.
-To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (recommended version: [v0.133.1](https://github.com/gohugoio/hugo/releases/tag/v0.133.1)).
+To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (recommended version: [v0.147.9](https://github.com/gohugoio/hugo/releases/tag/v0.147.9)).
 
 - The recommended command to start the local hugo server is `hugo serve -D -s hugo --disableFastRender --logLevel debug --watch`.
   - This will render and live-reload all pages, including drafts. _To suppress rendering of drafts, omit the `-D` flag._

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 The following development with Hugo will be sufficient for most of the DORA.dev website development efforts.
 To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (recommended version: [v0.133.1](https://github.com/gohugoio/hugo/releases/tag/v0.133.1)).
 
-- The recommended command to start the local hugo server is `hugo serve -D -s hugo --disableFastRender --debug --watch`.
+- The recommended command to start the local hugo server is `hugo serve -D -s hugo --disableFastRender --logLevel debug --watch`.
   - This will render and live-reload all pages, including drafts. _To suppress rendering of drafts, omit the `-D` flag._
 - When the hugo server is running, the site can be previewed at `localhost:1313`.
 

--- a/hugo/themes/dora-2025/assets/scss/research.scss
+++ b/hugo/themes/dora-2025/assets/scss/research.scss
@@ -1,7 +1,7 @@
 @import "_variables.scss";
 
 h3 {
-    margin-top:1.5em;
+    margin-top: 1.5em;
 }
 
 #rotate-tip {
@@ -15,15 +15,15 @@ h3 {
 }
 
 .hasSidebar article {
-    padding:1rem;
+    padding: 1rem;
 
     img {
-        max-width:100%;
+        max-width: 100%;
     }
 
     li {
         font-family: $font-roboto;
-        font-weight:300;
+        font-weight: 300;
     }
 
     .responsive-svg {
@@ -31,9 +31,12 @@ h3 {
         min-width: 815px;
     }
 
-    @media (max-width: 799px) {  /* Adjust breakpoint as needed */
+    @media (max-width: 799px) {
+
+        /* Adjust breakpoint as needed */
         .responsive-svg {
-            min-width: 0; /* Or min-width: auto; */
+            min-width: 0;
+            /* Or min-width: auto; */
         }
     }
 }
@@ -47,30 +50,32 @@ h3 {
         color: #666;
         margin-bottom: 1em;
     }
+
     li {
         font-weight: 300;
         font-family: "Roboto";
-        font-size:.9rem;
+        font-size: .9rem;
     }
+
     p.description {
         border-top: 1px solid lightgray;
     }
 
     .responses {
 
-        margin-bottom:.5rem;
+        margin-bottom: .5rem;
 
         label {
             font-family: $font-roboto;
-            font-size:.75rem;
+            font-size: .75rem;
             font-weight: normal;
         }
 
         .answer {
             display: inline-block;
-            font-size:.8rem;
+            font-size: .8rem;
             border: none;
-            color:$color-text-medium;
+            color: $color-text-medium;
             background-color: $background-light;
             border-radius: 0.25rem;
             padding: .25rem 0.5rem;
@@ -81,35 +86,33 @@ h3 {
 
 // Wider page allows room for Core diagram
 main:has(#app) {
-  padding:0;
+    padding: 0;
 }
 
 tab_links {
-    display:block;
-    width:100%;
+    display: block;
+    width: 100%;
     border-bottom: 1px solid $border-light;
+    padding-bottom: 1rem;
 
     a {
         display: inline-block;
         padding: 4px 18px;
-        cursor:pointer;
+        margin: 4px;
+        border-radius: 50vh;
+        cursor: pointer;
 
-        font-family: $font-roboto;
-        font-weight: 400;
+        font-weight: 700;
         font-size: 0.85rem;
         text-decoration: none;
-        color: $color-text-light;
-        text-transform: uppercase;
-        border-bottom: 2px solid white;
-        transition: border-bottom 400ms ease-out;
+        color: var(--dora-primary-dark);
+        border: 2px solid var(--dora-primary-dark);
+        transition: all 200ms ease-out;
 
+        &.selected,
         &:hover {
-            color: $color-text;
-        }
-
-        &.selected {
-            color: $color-text;
-            border-bottom: 2px solid $color-link;
+            background-color: var(--dora-primary-dark);
+            color: var(--dora-primary-light);
         }
     }
 }

--- a/hugo/themes/dora-2025/layouts/_default/home.html
+++ b/hugo/themes/dora-2025/layouts/_default/home.html
@@ -4,7 +4,7 @@
 
 <head>
   {{- partial "head" . -}}
-  {{- partial "partials/link_styles" "scss/homepage.scss" -}}
+  {{- partial "link_styles" "scss/homepage.scss" -}}
 </head>
 
 <body>

--- a/hugo/themes/dora-2025/layouts/capabilities/section.html
+++ b/hugo/themes/dora-2025/layouts/capabilities/section.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-    {{- partial "partials/link_styles" "scss/capabilities.scss" -}}
+    {{- partial "link_styles" "scss/capabilities.scss" -}}
 
     {{ range (slice "climate for learning" "fast flow" "fast feedback") }}
         {{ if eq . "climate for learning" }}

--- a/hugo/themes/dora-2025/layouts/capabilities/single.html
+++ b/hugo/themes/dora-2025/layouts/capabilities/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles"  "scss/capabilities.scss" -}}
+{{- partial "link_styles"  "scss/capabilities.scss" -}}
 
 <h4><a href="/capabilities">Capabilities</a>: {{ .Params.category }}</h4>
 <h1>

--- a/hugo/themes/dora-2025/layouts/faq/section.html
+++ b/hugo/themes/dora-2025/layouts/faq/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/faq.scss" -}}
+    {{- partial "link_styles" "scss/faq.scss" -}}
 
     {{ .Content }}
 {{ end }}

--- a/hugo/themes/dora-2025/layouts/faq/single.html
+++ b/hugo/themes/dora-2025/layouts/faq/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/faq.scss" -}}
+    {{- partial "link_styles" "scss/faq.scss" -}}
 
     {{ .Content }}
 {{ end }}

--- a/hugo/themes/dora-2025/layouts/guides/section.html
+++ b/hugo/themes/dora-2025/layouts/guides/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/guides.scss" -}}
+{{- partial "link_styles" "scss/guides.scss" -}}
 {{ .Content }}
 <grid class="guides-index">
   {{ range sort .Pages }}

--- a/hugo/themes/dora-2025/layouts/guides/single.html
+++ b/hugo/themes/dora-2025/layouts/guides/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <!-- TODO: remove this capabilities stylesheet -->
-{{- partial "partials/link_styles" "scss/capabilities.scss" -}}
-{{- partial "partials/link_styles" "scss/guides.scss" -}}
+{{- partial "link_styles" "scss/capabilities.scss" -}}
+{{- partial "link_styles" "scss/guides.scss" -}}
 
 <div class="guides-article">
   <div class="guides-header">

--- a/hugo/themes/dora-2025/layouts/partials/head.html
+++ b/hugo/themes/dora-2025/layouts/partials/head.html
@@ -12,7 +12,7 @@
 
 
 <title>DORA | {{ if .Params.TitleForHTMLHead }}{{ .Params.TitleForHTMLHead }}{{ else }}{{ .Title }}{{ end }}</title>
-{{- partial "partials/link_styles" "scss/main.scss" -}}
+{{- partial "link_styles" "scss/main.scss" -}}
 {{ partial "quickcheck_variables_link" . }}
 
 <meta name="description" content="{{ .Site.Params.Description }}">

--- a/hugo/themes/dora-2025/layouts/partials/link_styles.html
+++ b/hugo/themes/dora-2025/layouts/partials/link_styles.html
@@ -7,7 +7,7 @@
 
     Example:
     Given the following Layout or top level partial:
-            partial "partials/link_styles" "scss/homepage.scss"
+            partial "link_styles" "scss/homepage.scss"
 
         This, this partial will receive '.' as `scss/main.scss`.  Then, this partial
             will apply the href to the Hugo transpiled version of the file
@@ -19,7 +19,7 @@
         To support options, you would need to refactor the Layouts to pass in a
         Dictionary object.
 
-        e.g.,  partial "partials/link_styles" (dict "scss" "scss/main.scss")
+        e.g.,  partial "link_styles" (dict "scss" "scss/main.scss")
 
         then in this file:
             1) add a default for options:  $options := .options | default ""

--- a/hugo/themes/dora-2025/layouts/publications/section.html
+++ b/hugo/themes/dora-2025/layouts/publications/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/publications.scss" -}}
+{{- partial "link_styles" "scss/publications.scss" -}}
 <section class="publications">
     <article>
         {{ .Content }}

--- a/hugo/themes/dora-2025/layouts/publications/single.html
+++ b/hugo/themes/dora-2025/layouts/publications/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/publications.scss" -}}
+{{- partial "link_styles" "scss/publications.scss" -}}
 <section class="publications">
     <article>
         {{ .Content }}

--- a/hugo/themes/dora-2025/layouts/quickcheck/section.html
+++ b/hugo/themes/dora-2025/layouts/quickcheck/section.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
-  {{- partial "partials/link_styles" "scss/quickcheck.scss" -}}
+  {{- partial "link_styles" "scss/quickcheck.scss" -}}
     {{ .Content }}
 {{ end }}

--- a/hugo/themes/dora-2025/layouts/research/research_team.html
+++ b/hugo/themes/dora-2025/layouts/research/research_team.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/headshots.scss" -}}
+    {{- partial "link_styles" "scss/headshots.scss" -}}
     <section class="features">
         {{ .Content }}
 

--- a/hugo/themes/dora-2025/layouts/research/section.html
+++ b/hugo/themes/dora-2025/layouts/research/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 {{ .Content }}
 
 <section>

--- a/hugo/themes/dora-2025/layouts/research_archives/preview/single.html
+++ b/hugo/themes/dora-2025/layouts/research_archives/preview/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 
 <h1>DORA Research: {{ .Params.research_collection }}</h1>
 {{- partial "research_archives_tabs" . -}}

--- a/hugo/themes/dora-2025/layouts/research_archives/questions/single.html
+++ b/hugo/themes/dora-2025/layouts/research_archives/questions/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 
 {{ $researchCollectionTitle := "" }}
 {{ if .Params.research_collection_title }}

--- a/hugo/themes/dora-2025/layouts/research_archives/single.html
+++ b/hugo/themes/dora-2025/layouts/research_archives/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 
 <h1>DORA Research: {{ .Params.research_collection }}</h1>
 {{- partial "research_archives_tabs" . -}}

--- a/hugo/themes/dora-2025/layouts/search/section.html
+++ b/hugo/themes/dora-2025/layouts/search/section.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div id="searchPage">
-    {{- partial "partials/link_styles" "scss/search.scss" -}}
-    {{- partial "partials/search_input" -}}
+    {{- partial "link_styles" "scss/search.scss" -}}
+    {{- partial "search_input" -}}
     {{ .Content }}
 </div>
 {{ end }}

--- a/hugo/themes/dora-2025/theme.toml
+++ b/hugo/themes/dora-2025/theme.toml
@@ -8,7 +8,7 @@ description = ""
 homepage = ""
 tags = []
 features = []
-min_version = "v0.114.1+extended"
+min_version = "v0.147.9+extended"
 
 [author]
   name = "DevOps Research + Assessment"

--- a/hugo/themes/dora/layouts/capabilities/section.html
+++ b/hugo/themes/dora/layouts/capabilities/section.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-    {{- partial "partials/link_styles" "scss/capabilities.scss" -}}
+    {{- partial "link_styles" "scss/capabilities.scss" -}}
 
     {{ range (slice "climate for learning" "fast flow" "fast feedback") }}
         {{ if eq . "climate for learning" }}

--- a/hugo/themes/dora/layouts/capabilities/single.html
+++ b/hugo/themes/dora/layouts/capabilities/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles"  "scss/capabilities.scss" -}}
+{{- partial "link_styles"  "scss/capabilities.scss" -}}
 
 <h4><a href="/capabilities">Capabilities</a>: {{ .Params.category }}</h4>
 <h1>

--- a/hugo/themes/dora/layouts/faq/section.html
+++ b/hugo/themes/dora/layouts/faq/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/faq.scss" -}}
+    {{- partial "link_styles" "scss/faq.scss" -}}
 
     {{ .Content }}
 {{ end }}

--- a/hugo/themes/dora/layouts/faq/single.html
+++ b/hugo/themes/dora/layouts/faq/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/faq.scss" -}}
+    {{- partial "link_styles" "scss/faq.scss" -}}
 
     {{ .Content }}
 {{ end }}

--- a/hugo/themes/dora/layouts/guides/section.html
+++ b/hugo/themes/dora/layouts/guides/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/guides.scss" -}}
+{{- partial "link_styles" "scss/guides.scss" -}}
 {{ .Content }}
 <grid class="guides-index">
   {{ range sort .Pages }}

--- a/hugo/themes/dora/layouts/guides/single.html
+++ b/hugo/themes/dora/layouts/guides/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <!-- TODO: remove this capabilities stylesheet -->
-{{- partial "partials/link_styles" "scss/capabilities.scss" -}}
-{{- partial "partials/link_styles" "scss/guides.scss" -}}
+{{- partial "link_styles" "scss/capabilities.scss" -}}
+{{- partial "link_styles" "scss/guides.scss" -}}
 
 <div class="guides-article">
   <div class="guides-header">

--- a/hugo/themes/dora/layouts/index.html
+++ b/hugo/themes/dora/layouts/index.html
@@ -3,7 +3,7 @@
     <p>{{ .Params.bannerSubtitle }}</p>
 {{ end }}
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/homepage.scss" -}}
+    {{- partial "link_styles" "scss/homepage.scss" -}}
     <section class="features">
         {{ .Content }}
     </section>

--- a/hugo/themes/dora/layouts/partials/head.html
+++ b/hugo/themes/dora/layouts/partials/head.html
@@ -12,7 +12,7 @@
 
 
 <title>DORA | {{ if .Params.TitleForHTMLHead }}{{ .Params.TitleForHTMLHead }}{{ else }}{{ .Title }}{{ end }}</title>
-{{- partial "partials/link_styles" "scss/main.scss" -}}
+{{- partial "link_styles" "scss/main.scss" -}}
 {{ partial "quickcheck_variables_link" . }}
 
 <meta name="description" content="{{ .Site.Params.Description }}">

--- a/hugo/themes/dora/layouts/partials/link_styles.html
+++ b/hugo/themes/dora/layouts/partials/link_styles.html
@@ -7,7 +7,7 @@
 
     Example:
     Given the following Layout or top level partial:
-            partial "partials/link_styles" "scss/homepage.scss"
+            partial "link_styles" "scss/homepage.scss"
 
         This, this partial will receive '.' as `scss/main.scss`.  Then, this partial
             will apply the href to the Hugo transpiled version of the file
@@ -19,7 +19,7 @@
         To support options, you would need to refactor the Layouts to pass in a
         Dictionary object.
 
-        e.g.,  partial "partials/link_styles" (dict "scss" "scss/main.scss")
+        e.g.,  partial "link_styles" (dict "scss" "scss/main.scss")
 
         then in this file:
             1) add a default for options:  $options := .options | default ""

--- a/hugo/themes/dora/layouts/publications/section.html
+++ b/hugo/themes/dora/layouts/publications/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/publications.scss" -}}
+{{- partial "link_styles" "scss/publications.scss" -}}
 <section class="publications">
     <article>
         {{ .Content }}

--- a/hugo/themes/dora/layouts/publications/single.html
+++ b/hugo/themes/dora/layouts/publications/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/publications.scss" -}}
+{{- partial "link_styles" "scss/publications.scss" -}}
 <section class="publications">
     <article>
         {{ .Content }}

--- a/hugo/themes/dora/layouts/research/research_team.html
+++ b/hugo/themes/dora/layouts/research/research_team.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    {{- partial "partials/link_styles" "scss/headshots.scss" -}}
+    {{- partial "link_styles" "scss/headshots.scss" -}}
     <section class="features">
         {{ .Content }}
 

--- a/hugo/themes/dora/layouts/research/section.html
+++ b/hugo/themes/dora/layouts/research/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 {{ .Content }}
 
 <section>

--- a/hugo/themes/dora/layouts/research_archives/preview/single.html
+++ b/hugo/themes/dora/layouts/research_archives/preview/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 
 <h1>DORA Research: {{ .Params.research_collection }}</h1>
 {{- partial "research_archives_tabs" . -}}

--- a/hugo/themes/dora/layouts/research_archives/questions/single.html
+++ b/hugo/themes/dora/layouts/research_archives/questions/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 
 {{ $researchCollectionTitle := "" }}
 {{ if .Params.research_collection_title }}

--- a/hugo/themes/dora/layouts/research_archives/single.html
+++ b/hugo/themes/dora/layouts/research_archives/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{- partial "partials/link_styles" "scss/research.scss" -}}
+{{- partial "link_styles" "scss/research.scss" -}}
 
 <h1>DORA Research: {{ .Params.research_collection }}</h1>
 {{- partial "research_archives_tabs" . -}}

--- a/hugo/themes/dora/layouts/search/section.html
+++ b/hugo/themes/dora/layouts/search/section.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div id="searchPage">
-    {{- partial "partials/link_styles" "scss/search.scss" -}}
-    {{- partial "partials/search_input" -}}
+    {{- partial "link_styles" "scss/search.scss" -}}
+    {{- partial "search_input" -}}
     {{ .Content }}
 </div>
 {{ end }}


### PR DESCRIPTION
This PR changes the style of research archive tabs to be more in line with the "DORA 2025" theme, and to look better if there are more than one row of tabs.

It also updates the Hugo recommended version (and the version used by CI) to `0.147.9`

Preview: https://doradotdev--pr1019-drafts-on-p9xswja6.web.app/research/ai/