### PR TITLE
Remove survey logos, the survey is closed

### DIFF
--- a/hugo/content/brand-guidelines/_index.md
+++ b/hugo/content/brand-guidelines/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "DORA Brand Guidelines"
 date: 2024-10-01T20:58:12-04:00
-updated: 2025-04-16
+updated: 2025-07-22
 draft: false
 bannerTitle: DORA Brand Guidelines
 layout: single
@@ -20,8 +20,6 @@ Please refer to our [brand guidelines](https://storage.googleapis.com/dora-brand
 * [DORA Logos](https://storage.googleapis.com/dora-brand-2024/DORA-Logo.zip) <small>(ZIP, 449KB)</small>
 
 * [DORA Community Logos](https://storage.googleapis.com/dora-brand-2024/DORA-Community-Logo.zip) <small>(ZIP, 4.9MB)</small>
-
-* [DORA Survey Logos](https://storage.googleapis.com/dora-sponsor-resources/DORA-survey-graphics-2025.zip) <small>(ZIP, 1.1MB)</small>
 
 ## Impact of Generative AI on Software Development report graphics
 

--- a/test/playwright/tests/brand-guidelines/dora-brand-guidelines.spec.ts
+++ b/test/playwright/tests/brand-guidelines/dora-brand-guidelines.spec.ts
@@ -9,20 +9,24 @@ export const pageHeaders = [
   '2024 DORA Report graphics'
 ];
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('/brand-guidelines/');
-});
+test.describe('DORA brand guidelines', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/brand-guidelines/');
+  });
 
-test('DORA brand guidelines has the correct title.', async ({ page }) => {
-  await expect(page).toHaveTitle('DORA | DORA Brand Guidelines');
-});
+  test('has the correct title', async ({ page }) => {
+    await expect(page).toHaveTitle('DORA | DORA Brand Guidelines');
+  });
 
-test('DORA brand guidelines has the correct header.', async ({ page }) => {
-  await expect(page.locator('h1')).toContainText('DORA Brand Guidelines');
-});
+  test('has the correct header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('DORA Brand Guidelines');
+  });
 
-pageHeaders.forEach((pageHeader, index) => {
-  test(`DORA brand guidelines has a ${pageHeader} header.`, async ({ page }) => {
-    await expect(page.locator('h2').nth(index)).toContainText(pageHeader);
+  pageHeaders.forEach((pageHeader) => {
+    test(`has a ${pageHeader} header`, async ({ page }) => {
+      await expect(
+        page.getByRole('heading', { name: pageHeader, level: 2, exact: true })
+      ).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
Removes link to the logos.

Refactors the playwright tests for the page to make them more maintainable

Preview URL: https://doradotdev--pr1046-drafts-off-97lantkj.web.app/brand-guidelines/

It should *not* have a link for DORA Survey Logos.