### PR TITLE
Version checker updates for 2025.1

### DIFF
--- a/hugo/content/vc/_index.md
+++ b/hugo/content/vc/_index.md
@@ -58,6 +58,8 @@ layout: single
     <a href="/research/2024/dora-report">Download the latest digital version of the 2024 DORA report</a>.
   </p>
   <a href="/research/2024/dora-report"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 DORA Report Cover" style="max-width:18em;"></a>
+  <h3>Newer DORA reports available</h3>
+  <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
 
 <!-- version is 2024.3 -->
@@ -71,6 +73,8 @@ layout: single
     Latest version: <code>v.2024.3</code>
   </p>
   <a href="/research/2024/dora-report"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 DORA Report Cover" style="max-width:18em;"></a>
+  <h3>Newer DORA reports available</h3>
+  <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
 
 <!-- version is 2024.2 -->
@@ -86,6 +90,8 @@ layout: single
   <p>
     <a href="/research/2024/dora-report">Download the latest version of the 2024 DORA report</a>.
   </p>
+  <h3>Newer DORA reports available</h3>
+  <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
 
 <!-- version is 2024.1 -->
@@ -101,6 +107,8 @@ layout: single
   <p>
     <a href="/research/2024/dora-report">Download the latest version of the 2024 DORA report</a>.
   </p>
+  <h3>Newer DORA reports available</h3>
+  <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
 
 <!-- version is 2023-12 -->
@@ -112,12 +120,8 @@ layout: single
   <p>
     Your version: <code>v.2023-12</code><br />
     Latest version: <code>v.2023-12</code><br />
-    <a href="/research/2023/errata/#errata-in-v2023-12">Errata for <code>v.2023-12</code>.</a>
-  </p>
-
-  <h3>2024 DORA Report</h3>
-  <p>The <a href="/research/2024/dora-report">2024 DORA Report</a> is now available for download.</p>
-  <a href="/research/2024/dora-report"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 DORA Report Cover" style="max-width:12em;"></a>
+  <h3>Newer DORA reports available</h3>
+  <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
 
 <!-- version is 2023-10 -->
@@ -134,9 +138,8 @@ layout: single
     <a href="/research/2023/dora-report">Download the latest version of the 2023 DORA report</a>.
   </p>
 
-  <h3>2024 DORA Report</h3>
-  <p>The <a href="/research/2024/dora-report">2024 DORA Report</a> is now available for download.</p>
-  <a href="/research/2024/dora-report"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 DORA Report Cover" style="max-width:12em;"></a>
+  <h3>Newer DORA reports available</h3>
+  <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
 
 <!-- version is 2025.1 -->

--- a/hugo/content/vc/_index.md
+++ b/hugo/content/vc/_index.md
@@ -120,6 +120,7 @@ layout: single
   <p>
     Your version: <code>v.2023-12</code><br />
     Latest version: <code>v.2023-12</code><br />
+  </p>
   <h3>Newer DORA reports available</h3>
   <p><a href="/publications">View all of DORA's publications</a>.</p>
 </div>
@@ -153,7 +154,7 @@ layout: single
     Latest version: <code>v.2025.1</code>
   </p>
   <p>
-    <a href="/research/2025/dora-report">Download the latest  version of the 2025 DORA report</a>.
+    <a href="/research/2025/dora-report">Download the latest version of the 2025 DORA report</a>.
   </p>
   <a href="/research/2025/dora-report"><img src="/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png" alt="2025 DORA Report Cover" style="max-width:18em;"></a>
 </div>

--- a/hugo/content/vc/_index.md
+++ b/hugo/content/vc/_index.md
@@ -21,6 +21,9 @@ layout: single
   <p>The following versions of the DORA Report are available via this version checker:</p>
   <ul>
     <li>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2025.1">2025 DORA Report <code>v. 2025.1</code></a>
+    </li>
+    <li>
       <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2024.3.p">2024 DORA Report (Printed Version) <code>v. 2024.3.p</code></a>
     </li>
     <li>
@@ -134,6 +137,22 @@ layout: single
   <h3>2024 DORA Report</h3>
   <p>The <a href="/research/2024/dora-report">2024 DORA Report</a> is now available for download.</p>
   <a href="/research/2024/dora-report"><img src="/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png" alt="2024 DORA Report Cover" style="max-width:12em;"></a>
+</div>
+
+<!-- version is 2025.1 -->
+<div class="version-content" data-version="2025.1">
+  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2025 DORA Report</h2>
+  <p>
+    You have the most recent version of the 2025 report.
+  </p>
+  <p>
+    Your version: <code>v.2025.1</code><br />
+    Latest version: <code>v.2025.1</code>
+  </p>
+  <p>
+    <a href="/research/2025/dora-report">Download the latest  version of the 2025 DORA report</a>.
+  </p>
+  <a href="/research/2025/dora-report"><img src="/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png" alt="2025 DORA Report Cover" style="max-width:18em;"></a>
 </div>
 
 <script src="/js/version-check-utils.js"></script>

--- a/test/playwright/tests/vc/version-check.spec.ts
+++ b/test/playwright/tests/vc/version-check.spec.ts
@@ -3,6 +3,12 @@ import { test, expect } from '@playwright/test';
 test.describe('Version Checker', () => {
   const versions = [
     {
+      version: '2025.1',
+      expectedText: '2025 DORA Report',
+      expectedImage:
+        '/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png',
+    },
+    {
       version: '2024.3',
       expectedText: '2024 DORA Report (Digital Version)',
       expectedImage:

--- a/test/playwright/tests/vc/version-check.spec.ts
+++ b/test/playwright/tests/vc/version-check.spec.ts
@@ -13,33 +13,39 @@ test.describe('Version Checker', () => {
       expectedText: '2024 DORA Report (Digital Version)',
       expectedImage:
         '/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png',
+      expectNewerReportsLink: true,
     },
     {
       version: '2024.3.p',
       expectedText: '2024 DORA Report (Printed Version)',
       expectedImage:
         '/research/2024/dora-report/2024-dora-accelerate-state-of-devops-report.png',
+      expectNewerReportsLink: true,
     },
     {
       version: '2024.2',
       expectedText: 'Outdated 2024 DORA Report',
+      expectNewerReportsLink: true,
     },
     {
       version: '2024.1',
       expectedText: 'Outdated 2024 DORA Report',
+      expectNewerReportsLink: true,
     },
     {
       version: '2023-12',
       expectedText: '2023 DORA Report',
+      expectNewerReportsLink: true,
     },
     {
       version: '2023-10',
       expectedText: 'Outdated 2023 DORA Report',
+      expectNewerReportsLink: true,
     },
   ];
 
   versions.forEach(
-    ({ version, expectedText, expectedImage }) => {
+    ({ version, expectedText, expectedImage, expectNewerReportsLink }) => {
       test.describe(`v ${version}`, () => {
         test.beforeEach(async ({ page }) => {
           await page.goto(`/vc/?v=${version}`);
@@ -55,6 +61,24 @@ test.describe('Version Checker', () => {
           test('shows the correct image', async ({ page }) => {
             const versionDiv = page.locator(`div[data-version="${version}"]`);
             await expect(versionDiv.getByRole('img')).toHaveAttribute('src', expectedImage);
+          });
+        }
+
+        if (expectNewerReportsLink) {
+          test('shows the "Newer Reports Available" section', async ({ page }) => {
+            const versionDiv = page.locator(`div[data-version="${version}"]`);
+            await expect(
+              versionDiv.getByRole('heading', { name: 'Newer DORA reports available', level: 3 }),
+            ).toBeVisible();
+            await expect(
+              versionDiv.getByRole('link', { name: "View all of DORA's publications" }),
+            ).toHaveAttribute('href', '/publications');
+          });
+        } else {
+          test('does not show the "Newer Reports Available" section', async ({ page }) => {
+            await expect(
+              page.getByRole('heading', { name: 'Newer DORA reports available', level: 3 }),
+            ).toBeHidden();
           });
         }
 


### PR DESCRIPTION
* Refactors the playwright tests for the version checker
* Adds version checker for version `2025.1`
* Adds link to all publications for all versions not in the latest year (2025)

Fixes #1057 

Preview URLs:
* https://doradotdev--pr1087-drafts-off-khyb7ij9.web.app/vc/
* https://doradotdev--pr1087-drafts-off-khyb7ij9.web.app/vc/?v=2025.1