### PR TITLE
feat(2025-report): Add errata section

### DIFF
--- a/hugo/content/contact/_index.md
+++ b/hugo/content/contact/_index.md
@@ -15,6 +15,8 @@ Do you have questions or suggestions about DORA research, or how to apply it in 
 
 **in a publication:** Have you found an error in one of our publications? Check to see if it has already been acknowledged in [DORA publications errata](/publications/errata/). If not, [contact us to report it](mailto:dora-advocacy@google.com?subject=DORA+Publication+error+report). Please include the publication title and page number.
 
+Please include the publication title and page number.
+
 #### Speaking engagement or workshop request
 Contact us at [dora-advocacy@google.com](mailto:dora-advocacy@google.com?subject=Speaking+engagement+or+workshop+request).
 

--- a/hugo/content/publications/errata.md
+++ b/hugo/content/publications/errata.md
@@ -6,6 +6,7 @@ draft: false
 
 # DORA Publications Errata
 
+### <a href='{{<relref "/research/2025/errata">}}'>State of AI-assisted Software Development 2025</a>
 ### <a href='{{<relref "/research/ai/errata">}}'>Impact of Generative AI in Software Development</a>
 ### <a href='{{<relref "/research/2024/errata">}}'>Accelerate State of DevOps 2024</a>
 ### <a href='{{<relref "/research/2023/errata">}}'>Accelerate State of DevOps 2023</a>

--- a/hugo/content/research/2025/errata.md
+++ b/hugo/content/research/2025/errata.md
@@ -1,0 +1,22 @@
+---
+title: "DORA Research: 2025 Errata"
+date: 2025-07-14
+draft: false
+research_collection: "2025"
+type: research_archives
+layout: single
+tab_order: "20"
+tab_title: "Errata"
+---
+## Errata for the 2025 DORA Report
+
+This page lists errors and corrections to the 2025 State of AI-assisted Software Development report. To track revisions, report PDFs are stamped with a version number. The initial version of the 2025 report is [`v.2025.1`]({{< ref "/research/2025/dora-report" >}}).
+
+At this time, there are no errata for the 2025 report.
+
+-----
+<div style="text-align:center; margin-top:2em;">
+Have you found an error in the 2025 State of AI-assisted Software Development report?
+
+<a href='mailto:dora-advocacy@google.com?subject=DORA+2025+State+of+AI-assisted+Software+Development+error+report' class='button' target="_blank">Submit a change or correction</a>
+</div>

--- a/test/playwright/tests/contact.spec.ts
+++ b/test/playwright/tests/contact.spec.ts
@@ -1,33 +1,32 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/contact/');
+  await page.goto("/contact/");
 });
 
-test('Contact page has the correct title.', async ({ page }) => {
-  await expect(page).toHaveTitle('DORA | Contact Us');
+test("Contact page has the correct title.", async ({ page }) => {
+  await expect(page).toHaveTitle("DORA | Contact Us");
 });
 
-test('Contact page has the correct header.', async ({ page }) => {
-  await expect(page.locator('h1')).toContainText('Contact DORA');
+test("Contact page has the correct header.", async ({ page }) => {
+  await expect(page.locator("h1")).toContainText("Contact DORA");
 });
 
-const emailAddresses = [
-  'dora-advocacy@google.com',
-  'sponsor-dora@google.com',
-];
+const emailAddresses = ["dora-advocacy@google.com", "sponsor-dora@google.com"];
 
 for (const emailAddress of emailAddresses) {
-  test(`Contact page has mail to link for ${emailAddress}.`, async ({ page }) => {
+  test(`Contact page has mail to link for ${emailAddress}.`, async ({
+    page,
+  }) => {
     // Find the firsst link that contains the email address
-    const emailLink = page.getByRole('link', { name: emailAddress }).first();
+    const emailLink = page.getByRole("link", { name: emailAddress }).first();
 
     // Check if the link is visible
     await expect(emailLink).toBeVisible();
 
     // Check if the link starts with the correct href attribute.
     // This accomodates a query string, like a subject, in the link
-    const href = await emailLink.getAttribute('href');
+    const href = await emailLink.getAttribute("href");
     expect(href).not.toBeNull();
     expect(href?.startsWith(`mailto:${emailAddress}`)).toBe(true);
   });

--- a/test/playwright/tests/research/2025/2025-errata.spec.ts
+++ b/test/playwright/tests/research/2025/2025-errata.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { sidebarLinks } from "../sidebarLinks";
+
+test.describe("2025 research errata", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/research/2025/errata/");
+  });
+
+  test("has the correct title.", async ({ page }) => {
+    await expect(page).toHaveTitle("DORA | DORA Research: 2025 Errata");
+  });
+
+  test("has the correct header.", async ({ page }) => {
+    await expect(page.locator("h1")).toContainText("DORA Research: 2025");
+  });
+
+  test("has the correct sidebar.", async ({ page }) => {
+    for (const sidebarLink of sidebarLinks) {
+      await expect(
+        page.getByRole("link", { name: sidebarLink, exact: true }),
+      ).toBeVisible();
+    }
+  });
+});
+


### PR DESCRIPTION
Adds a new errata section for the 2025 DORA report.

This includes:
 - A new page at /research/2025/errata/ to display errata.
 - An updated contact form to allow users to submit errata for the 2025 report.
 - New and updated Playwright tests to cover the new functionality.

Fixes #1049

Preview URLs:
* https://doradotdev--pr1094-drafts-off-xc5dwat9.web.app/publications/errata/
* https://doradotdev--pr1094-drafts-off-xc5dwat9.web.app/research/2025/errata/