### PR TITLE
v. 2025.2 of State of AI-assisted Software Development repot

### DIFF
--- a/hugo/content/research/2025/errata/index.md
+++ b/hugo/content/research/2025/errata/index.md
@@ -11,41 +11,47 @@ tab_title: "Errata"
 ---
 ## Errata for the 2025 DORA Report
 
-This page lists errors and corrections to the 2025 State of AI-assisted Software Development report. To track revisions, report PDFs are stamped with a version number. The initial version of the 2025 report is [`v.2025.1`]({{< ref "/research/2025/dora-report" >}}).
+This page lists errors and corrections to the 2025 State of AI-assisted Software Development report. To track revisions, report PDFs are stamped with a version number. The initial version of the 2025 report was `v. 2025.1`. The latest version is [`v. 2025.2`]({{< ref "/research/2025/dora-report" >}}).
 
-### Errata in `v.2025.1`
+### Errata in `v. 2025.2`
 
-**p. 9** There is an extra "deployments" in "This shift helped enable 136,000 deployments deployments per day in 2015"
+Have you found an error in v. 2025.2 of the 2025 State of AI-assisted Software Development report?
 
-**p. 20** Figure 12: Distribution of deployment frequency responses from the 2025 DORA Survey. The deployment frequency in the second row should be "Between once per month and once every six months".
+<a href='mailto:dora-advocacy@google.com?subject=DORA+2025+State+of+AI-assisted+Software+Development+error+report' class='button' target="_blank">Submit a change or correction</a>
 
-**p. 44** Figure 29: Estimated effect of AI adoption score scaled on key outcomes. "Existential oonnection" on the Y-axis should be "Existential connection"
+### Errata in `v. 2025.1`
 
-**p. 46** Figure 30: Ownership. The figure does not have a key explaining the meaning of the colors.
+**p. 9** There is an extra "deployments" in "This shift helped enable 136,000 deployments deployments per day in 2015"  _[Corrected in `v. 2025.2`]_
+
+**p. 20** Figure 12: Distribution of deployment frequency responses from the 2025 DORA Survey. The deployment frequency in the second row should be "Between once per month and once every six months".  _[Corrected in `v. 2025.2`]_
+
+**p. 44** Figure 29: Estimated effect of AI adoption score scaled on key outcomes. "Existential oonnection" on the Y-axis should be "Existential connection"  _[Corrected in `v. 2025.2`]_
+
+**p. 46** Figure 30: Ownership. The figure does not have a key explaining the meaning of the colors.  _[Corrected in `v. 2025.2`]_
 
 * Light blue ![light blue color swatch](light-blue.png) is No AI.
 * Dark purple ![dark purple color swatch](dark-purple.png) is AI.
 
-**p. 52** Figure 34 has an incorrect title and caption.
+**p. 52** Figure 34 has an incorrect title and caption.  _[Corrected in `v. 2025.2`]_
 
 * The correct title is "A clear and communicated AI stance moderates AI’s impact on software delivery throughput"
 * The correct caption is "Figure 34: A clear and communicated AI stance moderates AI’s impact on software delivery throughput"
 
-**p. 57** Figure 38 has an incorrect title and caption.
+**p. 57** Figure 38 has an incorrect title and caption.  _[Corrected in `v. 2025.2`]_
 
 * The correct title is "Version control commit frequency moderates AI’s impact on individual effectiveness"
 * The correct caption is "Figure 38: Version control commit frequency moderates AI’s impact on individual effectiveness"
 
-**p. 97** Footnote 1 should link to [https://dora.dev/research/2025/questions](/research/2025/questions).
+**p. 97** Footnote 1 should link to [https://dora.dev/research/2025/questions](/research/2025/questions).  _[Corrected in `v. 2025.2`]_
 
-**p. 100** "He has studied the deployment of intelligent technologies since 2011." has an unnecessary space at the beginning of the sentence.
+**p. 100** "He has studied the deployment of intelligent technologies since 2011." has an unnecessary space at the beginning of the sentence.  _[Corrected in `v. 2025.2`]_
 
-**p. 107** Figure 61: Programming language usage. There are a few errors in the list of programming languages:
+**p. 107** Figure 61: Programming language usage. There are a few errors in the list of programming languages:  _[Corrected in `v. 2025.2`]_
 
 * The list includes two entries for "C". The first should be "C#” (18.5%) and the second should be "C” (3.9%).
 * It lists "C+” as a language. It should be "C++” (14.5%).
 
-**p. 115** The description for one of the core analysis variables, `ai_adoption`, is incorrect. It should state: "`ai_adoption` = a factor made of three indicators".
+**p. 115** The description for one of the core analysis variables, `ai_adoption`, is incorrect. It should state: "`ai_adoption` = a factor made of three indicators".  _[Corrected in `v. 2025.2`]_
 
 -----
 <div style="text-align:center; margin-top:2em;">

--- a/hugo/content/vc/_index.md
+++ b/hugo/content/vc/_index.md
@@ -21,7 +21,10 @@ layout: single
   <p>The following versions of the DORA Report are available via this version checker:</p>
   <ul>
     <li>
-      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2025.1">2025 DORA Report <code>v. 2025.1</code></a>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2025.2">2025 DORA Report <code>v. 2025.2</code></a>
+    </li>
+    <li>
+      <span class="google-material-icons" style="color: orange; font-size:1em;">warning</span> <a href="/vc?v=2025.1">2025 DORA Report <code>v. 2025.1</code></a>
     </li>
     <li>
       <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2024.3.p">2024 DORA Report (Printed Version) <code>v. 2024.3.p</code></a>
@@ -42,6 +45,34 @@ layout: single
       <span class="google-material-icons" style="color: orange; font-size:1em;">warning</span> <a href="/vc?v=2023-10">2023 DORA Report <code>v. 2023-10</code></a>
     </li>
   </ul>
+</div>
+
+<!-- version is 2025.2 -->
+<div class="version-content" data-version="2025.2">
+  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2025 DORA Report</h2>
+  <p>
+    You have the most recent version of the 2025 report.
+  </p>
+  <p>
+    Your version: <code>v.2025.2</code><br />
+    Latest version: <code>v.2025.2</code>
+  </p>
+  <a href="/research/2025/dora-report"><img src="/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png" alt="2025 DORA Report Cover" style="max-width:18em;"></a>
+</div>
+
+<!-- version is 2025.1 -->
+<div class="version-content" data-version="2025.1">
+  <h2><span class="google-material-icons" style="color: orange; font-size:1em;">warning</span>Outdated 2025 DORA Report</h2>
+  <p>
+    You have an older version of the 2025 report.
+  </p>
+  <p>
+    Your version: <code>v.2025.1</code><br />
+    Latest version: <code>v.2025.2</code>
+  </p>
+  <p>
+    <a href="/research/2025/dora-report">Download the latest version of the 2025 DORA report</a>.
+  </p>
 </div>
 
 <!-- version is 2024.3.p -->
@@ -141,22 +172,6 @@ layout: single
 
   <h3>Newer DORA reports available</h3>
   <p><a href="/publications">View all of DORA's publications</a>.</p>
-</div>
-
-<!-- version is 2025.1 -->
-<div class="version-content" data-version="2025.1">
-  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2025 DORA Report</h2>
-  <p>
-    You have the most recent version of the 2025 report.
-  </p>
-  <p>
-    Your version: <code>v.2025.1</code><br />
-    Latest version: <code>v.2025.1</code>
-  </p>
-  <p>
-    <a href="/research/2025/dora-report">Download the latest version of the 2025 DORA report</a>.
-  </p>
-  <a href="/research/2025/dora-report"><img src="/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png" alt="2025 DORA Report Cover" style="max-width:18em;"></a>
 </div>
 
 <script src="/js/version-check-utils.js"></script>

--- a/test/playwright/tests/vc/version-check.spec.ts
+++ b/test/playwright/tests/vc/version-check.spec.ts
@@ -3,10 +3,14 @@ import { test, expect } from '@playwright/test';
 test.describe('Version Checker', () => {
   const versions = [
     {
-      version: '2025.1',
+      version: '2025.2',
       expectedText: '2025 DORA Report',
       expectedImage:
         '/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png',
+    },
+    {
+      version: '2025.1',
+      expectedText: 'Outdated 2025 DORA Report',
     },
     {
       version: '2024.3',


### PR DESCRIPTION
Adds version 2025.2 of the State of AI-assisted Software Development report to the version checker. This is now the latest version of this report.

Updates the version checker page and Playwright tests to support the new version.


Preview URLs:

* https://doradotdev--pr1121-drafts-off-2eeu3nov.web.app/research/2025/errata/
* https://doradotdev--pr1121-drafts-off-2eeu3nov.web.app/vc/
* https://doradotdev--pr1121-drafts-off-2eeu3nov.web.app/vc/?v=2025.2
* https://doradotdev--pr1121-drafts-off-2eeu3nov.web.app/vc/?v=2025.1