### PR TITLE
Version Check for Abridged 2025 Report

### DIFF
--- a/hugo/content/vc/_index.md
+++ b/hugo/content/vc/_index.md
@@ -24,6 +24,9 @@ layout: single
       <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2025.2">2025 DORA Report <code>v. 2025.2</code></a>
     </li>
     <li>
+      <span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span> <a href="/vc?v=2025.2.a">2025 DORA Report (Abridged Version) <code>v. 2025.2.a</code></a>
+    </li>
+    <li>
       <span class="google-material-icons" style="color: orange; font-size:1em;">warning</span> <a href="/vc?v=2025.1">2025 DORA Report <code>v. 2025.1</code></a>
     </li>
     <li>
@@ -58,6 +61,28 @@ layout: single
     Latest version: <code>v.2025.2</code>
   </p>
   <a href="/research/2025/dora-report"><img src="/research/shared/dora-report-2025/2025-state-of-ai-assisted-software-development-report.png" alt="2025 DORA Report Cover" style="max-width:18em;"></a>
+</div>
+
+<!-- version is 2025.2.a -->
+<div class="version-content" data-version="2025.2.a">
+  <h2><span class="google-material-icons" style="color: green; font-size:1em;">check_circle</span>2025 DORA Report (Abridged Version)</h2>
+  <p>
+    You have the most recent version of the 2025 report.
+  </p>
+  <p>
+    Your version: <code>v.2025.2.a</code><br />
+    Latest version: <code>v.2025.2.a</code>
+  </p>
+  <grid class="border_none mt-1">
+    <item>
+      <a href="/research/2025/dora-report"><img src="/research/shared/dora-report-2025/2025-state-of-ai-assisted-software-development-report.png" alt="2025 DORA Report Cover" style="max-width:18em;"></a>
+    </item>
+    <item>
+      <p>
+        This is an abridged version of our 2025 report. The <a href="/research/2025/dora-report/">full report</a>, available only in English, offers a much deeper dive, including our complete data analysis, the new DORA AI Capabilities Model, a detailed breakdown of the seven team profiles we identified, and the full methodology behind our findings.
+      </p>
+    </item>
+  </grid>
 </div>
 
 <!-- version is 2025.1 -->

--- a/test/playwright/tests/vc/version-check.spec.ts
+++ b/test/playwright/tests/vc/version-check.spec.ts
@@ -64,7 +64,9 @@ test.describe('Version Checker', () => {
         test('shows the correct version information', async ({ page }) => {
           const versionDiv = page.locator(`div[data-version="${version}"]`);
           await expect(versionDiv).toBeVisible();
-          await expect(versionDiv.getByRole('heading', { name: expectedText, level: 2 })).toBeVisible();
+          await expect(
+            versionDiv.getByRole('heading', { name: expectedText, level: 2 }),
+          ).toBeVisible();
         });
 
         if (expectedImage) {


### PR DESCRIPTION
Added 2025.2.a to the list of known versions.

Added a test case for 2025.2.a to verify it displays the correct text and image.

Fixes #1152 

Preview URLs:
* https://doradotdev--pr1153-drafts-off-tn7xps61.web.app/vc
* https://doradotdev--pr1153-drafts-off-tn7xps61.web.app/vc/?v=2025.2.a