### PR TITLE
add GHA (disabled)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,10 @@
+# EXPERIMENTAL alternative CI configs using GitHub Actions.
+
+These actions require some variables to be configured on the containing repo:
+(Settings > Secrets and Variables > Actions)
+
+Repository variables:
+* `GOOGLE_CLOUD_PROJECT` -- name of the GCP project associated with this site's Firebase Hosting project
+
+Repository secrets:
+* `FIREBASE_SERVICE_ACCOUNT` -- complete JSON key of a GCP service account with role `roles/firebasehosting.admin` for `GOOGLE_CLOUD_PROJECT`

--- a/.github/workflows/deploy.yml.DISABLED
+++ b/.github/workflows/deploy.yml.DISABLED
@@ -1,0 +1,54 @@
+name: Deploy to prod
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'adrs/**'
+      - '.gemini/**'
+      - '.github/**'      
+      - '**/README.md'
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_drafts_off:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.details_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.147.9'
+          extended: true
+      - name: Build Svelte components
+        run: |
+          # build all svelte components (in parallel)
+          ./svelte/quick-check/build-quick-check.sh & \
+          ./svelte/core-v2/build-core.sh & \
+          ./svelte/experimental-ai-model/build-ai-model.sh & \
+          wait
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo --source=./hugo --logLevel=debug --minify
+      - name: Deploy to Firebase
+        id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          projectId: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live

--- a/.github/workflows/preview.yml.DISABLED
+++ b/.github/workflows/preview.yml.DISABLED
@@ -1,0 +1,118 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: 
+      - opened
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'adrs/**'
+      - '.gemini/**'
+      - '.github/**'      
+      - '**/README.md'
+  workflow_dispatch:
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_drafts_off:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.details_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.147.9'
+          extended: true
+      - name: Build Svelte components
+        run: |
+          # build all svelte components (in parallel)
+          ./svelte/quick-check/build-quick-check.sh & \
+          ./svelte/core-v2/build-core.sh & \
+          ./svelte/experimental-ai-model/build-ai-model.sh & \
+          wait
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo --source=./hugo --logLevel=debug --minify
+      - name: Deploy to Firebase
+        id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          expires: 30d
+          projectId: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          channelId: ${{ github.ref }}_drafts_off
+  build_drafts_on:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.details_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.147.9'
+          extended: true
+      - name: Build Svelte components
+        run: |
+          # build all svelte components (in parallel)
+          ./svelte/quick-check/build-quick-check.sh & \
+          ./svelte/core-v2/build-core.sh & \
+          ./svelte/experimental-ai-model/build-ai-model.sh & \
+          wait
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo --source=./hugo --logLevel=debug --buildDrafts --minify
+      - name: Deploy to Firebase
+        id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          expires: 30d
+          projectId: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          channelId: ${{ github.ref }}_drafts_on
+  # shard tests across multiple workers
+  test:
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
+    runs-on: ubuntu-latest
+    needs: build_drafts_on
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up playwright
+        working-directory: test/playwright
+        run: npm ci && npx playwright install --with-deps
+      - name: Playwright tests
+        working-directory: test/playwright
+        env:
+          PLAYWRIGHT_BASE_URL: ${{needs.build_drafts_on.outputs.preview_url}}
+        run: |
+          set -u
+          npx playwright test --max-failures=1 --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+  


### PR DESCRIPTION
This PR adds GitHub Actions configurations, but they're disabled. These replicate the functionality currently found in the ci folder.

supports #1170 