### PR TITLE
Ignore all playwright files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ svelte/**/dist/
 .idea/
 
 svelte/local/*
+
+# Playwright files
+**/test-results/
+**/playwright-report/
+**/blob-report/
+**/playwright/.cache/


### PR DESCRIPTION
Antigravity sometimes creates tests in a different directory. Update the `.gitignore` to ignore it when that happens.