### PR TITLE
Adds a temporary Platform Engineering capability

### DIFF
--- a/hugo/content/capabilities/platform-engineering/index.md
+++ b/hugo/content/capabilities/platform-engineering/index.md
@@ -1,0 +1,16 @@
+---
+title: "Platform Engineering"
+titleForHTMLHead: "Platform Engineering"
+slug: platform-engineering
+core: false
+ai: true
+date: 2024-01-01
+updated: 2024-12-08
+category: AI
+draft: false
+headline: "Platform engineering delivers shared capabilities and self-service platforms to reduce cognitive load and improve developer productivity."
+summary: "Platform engineering is the discipline of designing and building toolchains and workflows that enable self-service capabilities for software engineering organizations in the cloud-native era. Platform engineers provide an integrated product most often referred to as an 'Internal Developer Platform' covering the operational necessities of the entire lifecycle of an application."
+---
+
+
+{{< param summary >}}

--- a/hugo/themes/dora-2025/assets/scss/capabilities.scss
+++ b/hugo/themes/dora-2025/assets/scss/capabilities.scss
@@ -164,6 +164,18 @@ h1 a.core {
     vertical-align: middle;
 }
 
+h1 a.ai-badge {
+    display: inline-block;
+    background-color: $background-soft;
+    font-weight: 400;
+    font-size: 1rem;
+    line-height: 1rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    vertical-align: middle;
+}
+
 @include media-medium {
     .capabilitiesGrid {
         grid-template-columns: 1fr;

--- a/hugo/themes/dora-2025/layouts/capabilities/single.html
+++ b/hugo/themes/dora-2025/layouts/capabilities/single.html
@@ -1,17 +1,20 @@
 {{ define "main" }}
-{{- partial "link_styles"  "scss/capabilities.scss" -}}
+{{- partial "link_styles" "scss/capabilities.scss" -}}
 
-<h4><a href="/capabilities">Capabilities</a>: {{ .Params.category }}</h4>
+<h4 class="categories"><a href="/capabilities">Capabilities</a>: {{ .Params.category }}</h4>
 <h1>
     {{ .Title }}
-    {{ if .Params.core }}<a class="core" href='{{ relref . "/research/" }}'>core</a>{{ end }}
+    <span class="labels">
+        {{ if .Params.core }}<a class="core" href='{{ relref . "/research/" }}'>core</a>{{ end }}
+        {{ if .Params.ai }}<a class="ai-badge" href='{{ relref . "/ai/#explore-the-model" }}'>AI</a>{{ end }}
+    </span>
 </h1>
 {{ if .Params.authors }}
-    <div class="authors">
-        {{ range .Params.authors }}
-            <a href="{{ .url }}" target="blank">{{ .name }}</a>
-        {{ end }}
-    </div>
+<div class="authors">
+    {{ range .Params.authors }}
+    <a href="{{ .url }}" target="blank">{{ .name }}</a>
+    {{ end }}
+</div>
 {{ end }}
 <section class="hasSidebar">
     <article>
@@ -23,19 +26,19 @@
             <h5>Climate for Learning</h5>
             <ul>
                 {{ range (where (where .Site.RegularPages "Section" .Section) "Params.Category" "climate for learning").ByParam "Title" }}
-                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
                 {{ end }}
             </ul>
             <h5>Fast Flow</h5>
             <ul>
                 {{ range (where (where .Site.RegularPages "Section" .Section) "Params.Category" "fast flow").ByParam "Title" }}
-                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
                 {{ end }}
             </ul>
             <h5>Fast Feedback</h5>
             <ul>
                 {{ range (where (where .Site.RegularPages "Section" .Section) "Params.Category" "fast feedback").ByParam "Title" }}
-                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
                 {{ end }}
             </ul>
         </section>

--- a/svelte/ai-model/src/data.json
+++ b/svelte/ai-model/src/data.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Quality internal platform",
-      "id": "quality-internal-platform",
+      "id": "platform-engineering",
       "description": "A platform provides the automated, secure pathways that allow AI’s benefits to scale across the organization."
     },
     {
@@ -38,12 +38,36 @@
     }
   ],
   "outcomes": [
-    { "name": "Team performance", "id": "team-performance", "description": "The perceived effectiveness and collaborative strength of an individual’s immediate team." },
-    { "name": "Code quality", "id": "code-quality", "description": "An individual’s assessment of the quality of code underlying the primary application or service they work on." },
-    { "name": "Individual effectiveness", "id": "individual-effectiveness", "description": "An individual’s self-assessed effectiveness and sense of accomplishment at work." },
-    { "name": "Product performance", "id": "product-performance", "description": "The success and quality of the products or services the team is building, based on characteristics like helping users accomplish important tasks and keeping information safe, and performance metrics such as latency." },
-    { "name": "Reduced friction", "id": "reduced-friction", "description": "Friction is the result of obstacles which hinder an individual’s work. Lower amounts of friction are generally considered to be a positive outcome." },
-    { "name": "Software delivery throughput", "id": "software-delivery-throughput", "description": "The speed and efficiency of the software delivery process." },
+    {
+      "name": "Team performance",
+      "id": "team-performance",
+      "description": "The perceived effectiveness and collaborative strength of an individual’s immediate team."
+    },
+    {
+      "name": "Code quality",
+      "id": "code-quality",
+      "description": "An individual’s assessment of the quality of code underlying the primary application or service they work on."
+    },
+    {
+      "name": "Individual effectiveness",
+      "id": "individual-effectiveness",
+      "description": "An individual’s self-assessed effectiveness and sense of accomplishment at work."
+    },
+    {
+      "name": "Product performance",
+      "id": "product-performance",
+      "description": "The success and quality of the products or services the team is building, based on characteristics like helping users accomplish important tasks and keeping information safe, and performance metrics such as latency."
+    },
+    {
+      "name": "Reduced friction",
+      "id": "reduced-friction",
+      "description": "Friction is the result of obstacles which hinder an individual’s work. Lower amounts of friction are generally considered to be a positive outcome."
+    },
+    {
+      "name": "Software delivery throughput",
+      "id": "software-delivery-throughput",
+      "description": "The speed and efficiency of the software delivery process."
+    },
     {
       "name": "Organizational performance",
       "id": "organizational-performance",
@@ -51,22 +75,90 @@
     }
   ],
   "connections": [
-    { "from": "user-centric-focus", "to": "team-performance", "index": 0 },
-    { "from": "strong-version-control-practices", "to": "team-performance", "index": 1 },
-    { "from": "strong-version-control-practices", "to": "individual-effectiveness", "index": -1 },
-    { "from": "ai-accessible-internal-data", "to": "code-quality", "index": 0 },
-    { "from": "ai-accessible-internal-data", "to": "individual-effectiveness", "index": 0 },
-    { "from": "ai-accessible-internal-data", "to": "product-performance", "index": -1 },
-    { "from": "working-in-small-batches", "to": "individual-effectiveness", "index": 1 },
-    { "from": "working-in-small-batches", "to": "product-performance", "index": 0 },
-    { "from": "working-in-small-batches", "to": "reduced-friction", "index": -1 },
-    { "from": "clear-and-communicated-ai-stance", "to": "individual-effectiveness", "index": 2 },
-    { "from": "clear-and-communicated-ai-stance", "to": "product-performance", "index": 1 },
-    { "from": "clear-and-communicated-ai-stance", "to": "reduced-friction", "index": 0 },
-    { "from": "clear-and-communicated-ai-stance", "to": "software-delivery-throughput", "index": 0 },
-    { "from": "clear-and-communicated-ai-stance", "to": "organizational-performance", "index": -2 },
-    { "from": "quality-internal-platform", "to": "reduced-friction", "index": 1 },
-    { "from": "quality-internal-platform", "to": "organizational-performance", "index": -1 },
-    { "from": "healthy-data-ecosystems", "to": "organizational-performance", "index": 0 }
+    {
+      "from": "user-centric-focus",
+      "to": "team-performance",
+      "index": 0
+    },
+    {
+      "from": "strong-version-control-practices",
+      "to": "team-performance",
+      "index": 1
+    },
+    {
+      "from": "strong-version-control-practices",
+      "to": "individual-effectiveness",
+      "index": -1
+    },
+    {
+      "from": "ai-accessible-internal-data",
+      "to": "code-quality",
+      "index": 0
+    },
+    {
+      "from": "ai-accessible-internal-data",
+      "to": "individual-effectiveness",
+      "index": 0
+    },
+    {
+      "from": "ai-accessible-internal-data",
+      "to": "product-performance",
+      "index": -1
+    },
+    {
+      "from": "working-in-small-batches",
+      "to": "individual-effectiveness",
+      "index": 1
+    },
+    {
+      "from": "working-in-small-batches",
+      "to": "product-performance",
+      "index": 0
+    },
+    {
+      "from": "working-in-small-batches",
+      "to": "reduced-friction",
+      "index": -1
+    },
+    {
+      "from": "clear-and-communicated-ai-stance",
+      "to": "individual-effectiveness",
+      "index": 2
+    },
+    {
+      "from": "clear-and-communicated-ai-stance",
+      "to": "product-performance",
+      "index": 1
+    },
+    {
+      "from": "clear-and-communicated-ai-stance",
+      "to": "reduced-friction",
+      "index": 0
+    },
+    {
+      "from": "clear-and-communicated-ai-stance",
+      "to": "software-delivery-throughput",
+      "index": 0
+    },
+    {
+      "from": "clear-and-communicated-ai-stance",
+      "to": "organizational-performance",
+      "index": -2
+    },
+    {
+      "from": "platform-engineering",
+      "to": "reduced-friction",
+      "index": 1
+    },
+    {
+      "from": "platform-engineering",
+      "to": "organizational-performance",
+      "index": -1
+    },
+    {
+      "from": "healthy-data-ecosystems",
+      "to": "organizational-performance",
+      "index": 0
+    }
   ]
 }

--- a/test/playwright/tests/capabilities/platform-engineering.spec.ts
+++ b/test/playwright/tests/capabilities/platform-engineering.spec.ts
@@ -11,7 +11,7 @@ test.describe("Platform engineering capability", () => {
   });
 
   test("has the correct header", async ({ page }) => {
-    await expect(page.locator("h1")).toHaveText("Platform Engineering");
+    await expect(page.locator("h1")).toContainText("Platform Engineering");
   });
 
   test("displays its last updated date", async ({ page }) => {


### PR DESCRIPTION
This is a new capability to support the DORA AI Capabilities Model. 

The current iteration just a bit more than enough remove the 404 when clicking through from the model.

Supports #1198 

Preview URLs:
* https://doradotdev--pr1209-drafts-off-flfnzrl9.web.app/capabilities/platform-engineering/
* https://doradotdev--pr1209-drafts-off-flfnzrl9.web.app/ai/#explore-the-model