### PR TITLE
Fix dates on platform engineering capability

### DIFF
--- a/hugo/content/capabilities/platform-engineering/index.md
+++ b/hugo/content/capabilities/platform-engineering/index.md
@@ -4,8 +4,8 @@ titleForHTMLHead: "Platform Engineering"
 slug: platform-engineering
 core: false
 ai: true
-date: 2024-01-01
-updated: 2024-12-08
+date: 2025-12-08
+updated: 2025-12-08
 category: AI
 draft: false
 headline: "Platform engineering delivers shared capabilities and self-service platforms to reduce cognitive load and improve developer productivity."


### PR DESCRIPTION

Preview: https://doradotdev--pr1217-drafts-off-fqrm286e.web.app/capabilities/platform-engineering/

Updated date at the bottom of the page should be December 8, 2025