### PR TITLE
Restore author attribution to insights

### DIFF
--- a/hugo/themes/dora-2025/layouts/ai/single.html
+++ b/hugo/themes/dora-2025/layouts/ai/single.html
@@ -10,6 +10,15 @@
 <h1>{{ .Title }}</h1>
 {{ end }}
 
+{{ if .Params.authors }}
+<h4 class="authors">
+  by
+  {{ range .Params.authors }}
+  <a href="{{ .url }}" class="author" {{ if ne (substr .url 0 1) "/" }}target="_blank" {{ end }}>{{ .name }}</a>
+  {{ end }}
+</h4>
+{{ end }}
+
 <article class="ai-content">
   {{ .Content }}
   {{ if .Params.updated }}

--- a/hugo/themes/dora-2025/layouts/insights/single.html
+++ b/hugo/themes/dora-2025/layouts/insights/single.html
@@ -16,7 +16,7 @@
             <h4 class="authors">
                 by
                 {{ range .Params.authors }}
-                <a href="{{ .url }}" class="author" {{ if ne (substr .url 0 1) "/" }}target="blank" {{ end }}>{{ .name }}</a>
+                <a href="{{ .url }}" class="author" {{ if ne (substr .url 0 1) "/" }}target="_blank" {{ end }}>{{ .name }}</a>
                 {{ end }}
             </h4>
             {{ end }}

--- a/test/playwright/tests/ai/research-insights/adopt-gen-ai.spec.ts
+++ b/test/playwright/tests/ai/research-insights/adopt-gen-ai.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { LAST_UPDATED_DATE_REGEX } from '../../constants';
+import { verifyAuthors } from './shared';
 
 const pages = [
   {
@@ -30,6 +31,10 @@ for (const pageConfig of pages) {
 
     test('displays its last updated date', async ({ page }) => {
       await expect(page.locator('.updated')).toContainText(LAST_UPDATED_DATE_REGEX);
+    });
+
+    test('displays authors.', async ({ page }) => {
+      await verifyAuthors(page);
     });
   });
 }

--- a/test/playwright/tests/ai/research-insights/builder-mindset.spec.ts
+++ b/test/playwright/tests/ai/research-insights/builder-mindset.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { LAST_UPDATED_DATE_REGEX } from '../../constants';
+import { verifyAuthors } from './shared';
 
 const pages = [
   {
@@ -30,6 +31,10 @@ for (const pageConfig of pages) {
 
     test('displays its last updated date.', async ({ page }) => {
       await expect(page.locator('.updated')).toContainText(LAST_UPDATED_DATE_REGEX);
+    });
+
+    test('displays authors.', async ({ page }) => {
+      await verifyAuthors(page);
     });
   });
 }

--- a/test/playwright/tests/ai/research-insights/concerns-beyond-accuracy.spec.ts
+++ b/test/playwright/tests/ai/research-insights/concerns-beyond-accuracy.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { verifyAuthors } from './shared';
 
 const pages = [
   {
@@ -29,6 +30,10 @@ for (const pageConfig of pages) {
 
     test('displays its last updated date', async ({ page }) => {
       await expect(page.locator('.updated')).toContainText(/Last updated: \w+ \d{1,2}, \d{4}/);
+    });
+
+    test('displays authors.', async ({ page }) => {
+      await verifyAuthors(page);
     });
   });
 }

--- a/test/playwright/tests/ai/research-insights/measurement-frameworks.spec.ts
+++ b/test/playwright/tests/ai/research-insights/measurement-frameworks.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { sidebarLinks } from '../../research/sidebarLinks';
+import { verifyAuthors } from './shared';
 
 const pages = [
   {
@@ -39,6 +40,10 @@ for (const pageConfig of pages) {
         for (const sidebarLink of sidebarLinks) {
           await expect(page.getByRole('link', { name: sidebarLink, exact: true })).toBeVisible();
         }
+      });
+    } else {
+      test('displays authors.', async ({ page }) => {
+        await verifyAuthors(page);
       });
     }
   });

--- a/test/playwright/tests/ai/research-insights/shared.ts
+++ b/test/playwright/tests/ai/research-insights/shared.ts
@@ -1,0 +1,9 @@
+import { Page, expect } from '@playwright/test';
+
+export async function verifyAuthors(page: Page) {
+  const authorsHeading = page.locator('.authors');
+  await expect(authorsHeading).toBeVisible();
+  await expect(authorsHeading).toContainText('by');
+  // Verify at least one author link exists
+  await expect(page.locator('.authors .author').first()).toBeVisible();
+}

--- a/test/playwright/tests/ai/research-insights/trust-in-ai.spec.ts
+++ b/test/playwright/tests/ai/research-insights/trust-in-ai.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { LAST_UPDATED_DATE_REGEX } from '../../constants';
+import { verifyAuthors } from './shared';
 
 const pages = [
   {
@@ -30,6 +31,10 @@ for (const pageConfig of pages) {
 
     test('displays its last updated date', async ({ page }) => {
       await expect(page.locator('.updated')).toContainText(LAST_UPDATED_DATE_REGEX);
+    });
+
+    test('displays authors.', async ({ page }) => {
+      await verifyAuthors(page);
     });
   });
 }

--- a/test/playwright/tests/ai/research-insights/value-of-development-work.spec.ts
+++ b/test/playwright/tests/ai/research-insights/value-of-development-work.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { LAST_UPDATED_DATE_REGEX } from '../../constants';
+import { verifyAuthors } from './shared';
 
 const pages = [
   {
@@ -30,6 +31,10 @@ for (const pageConfig of pages) {
 
     test('displays its last updated date', async ({ page }) => {
       await expect(page.locator('.updated')).toContainText(LAST_UPDATED_DATE_REGEX);
+    });
+
+    test('displays authors.', async ({ page }) => {
+      await verifyAuthors(page);
     });
   });
 }


### PR DESCRIPTION
* Adds tests to prevent regression in the future.
* Adds authors back to the layout for AI research insights

Fixes #1237

Preview URLs:
* https://doradotdev--pr1238-drafts-off-r6au6hi7.web.app/ai/research-insights/builder-mindset/
* https://doradotdev--pr1238-drafts-off-r6au6hi7.web.app/ai/research-insights/measurement-frameworks/
* https://doradotdev--pr1238-drafts-off-r6au6hi7.web.app/ai/research-insights/concerns-beyond-accuracy-of-ai-output/
* https://doradotdev--pr1238-drafts-off-r6au6hi7.web.app/ai/research-insights/adopt-gen-ai/
* https://doradotdev--pr1238-drafts-off-r6au6hi7.web.app/ai/research-insights/value-of-development-work/
* https://doradotdev--pr1238-drafts-off-r6au6hi7.web.app/ai/research-insights/trust-in-ai/