### PR TITLE
feat: make archive labels clickable links

### DIFF
--- a/hugo/themes/dora-2025/assets/scss/research.scss
+++ b/hugo/themes/dora-2025/assets/scss/research.scss
@@ -237,6 +237,15 @@ tab_links {
             padding: 1.5rem 0;
             border-bottom: 1px solid var(--grey-30);
 
+            a.label-link {
+                text-decoration: none;
+                color: inherit;
+
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+
             .label {
                 font-family: $font-google-sans;
                 font-size: 1.1rem;

--- a/hugo/themes/dora-2025/layouts/partials/research_archives.html
+++ b/hugo/themes/dora-2025/layouts/partials/research_archives.html
@@ -1,66 +1,66 @@
 <span id="_pw-research-archives">
     <ul class="past-research-list">
         <li>
-            <span class="label">Artificial Intelligence</span>
+            <a href='{{ relref . "/ai/" }}' class="label-link"><span class="label">Artificial Intelligence</span></a>
             <a href='{{ relref . "/ai/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2025</span>
+            <a href='{{ relref . "/research/2025/" }}' class="label-link"><span class="label">2025</span></a>
             <a href='{{ relref . "/research/2025/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2024</span>
+            <a href='{{ relref . "/research/2024/" }}' class="label-link"><span class="label">2024</span></a>
             <a href='{{ relref . "/research/2024/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2023</span>
+            <a href='{{ relref . "/research/2023/" }}' class="label-link"><span class="label">2023</span></a>
             <a href='{{ relref . "/research/2023/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2022</span>
+            <a href='{{ relref . "/research/2022/" }}' class="label-link"><span class="label">2022</span></a>
             <a href='{{ relref . "/research/2022/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2021</span>
+            <a href='{{ relref . "/research/2021/" }}' class="label-link"><span class="label">2021</span></a>
             <a href='{{ relref . "/research/2021/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2020</span>
+            <a href='{{ relref . "/research/2020/" }}' class="label-link"><span class="label">2020</span></a>
             <a href='{{ relref . "/research/2020/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2019</span>
+            <a href='{{ relref . "/research/2019/" }}' class="label-link"><span class="label">2019</span></a>
             <a href='{{ relref . "/research/2019/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2018</span>
+            <a href='{{ relref . "/research/2018/" }}' class="label-link"><span class="label">2018</span></a>
             <a href='{{ relref . "/research/2018/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2017</span>
+            <a href='{{ relref . "/research/2017/" }}' class="label-link"><span class="label">2017</span></a>
             <a href='{{ relref . "/research/2017/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2016</span>
+            <a href='{{ relref . "/research/2016/" }}' class="label-link"><span class="label">2016</span></a>
             <a href='{{ relref . "/research/2016/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2015</span>
+            <a href='{{ relref . "/research/2015/" }}' class="label-link"><span class="label">2015</span></a>
             <a href='{{ relref . "/research/2015/" }}' class="button">View research</a>
         </li>
         <li>
-            <span class="label">2014</span>
+            <a href='{{ relref . "/research/2014/" }}' class="label-link"><span class="label">2014</span></a>
             <a href='{{ relref . "/research/2014/" }}' class="button">View research</a>
         </li>
     </ul>
     <h4 id="publications-legacy" style="margin-top: 3rem;">Additional Publications</h4>
     <ul class="past-research-list">
         <li>
-            <span class="label">The ROI of DevOps Transformation</span>
+            <a href='{{ relref . "/research/2020/" }}' class="label-link"><span class="label">The ROI of DevOps Transformation</span></a>
             <a href='{{ relref . "/research/2020/" }}' class="button">Download Whitepaper</a>
         </li>
         <li>
-            <span class="label">DevOps Awards Winners 2021</span>
+            <a href='https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf' target="_blank" class="label-link"><span class="label">DevOps Awards Winners 2021</span></a>
             <a href='https://services.google.com/fh/files/misc/devops_awards_fullebook_final.pdf' target="_blank" class="button">Read ebook</a>
         </li>
     </ul>

--- a/test/playwright/tests/research/index.spec.ts
+++ b/test/playwright/tests/research/index.spec.ts
@@ -22,6 +22,10 @@ test.describe('Research home page', () => {
 
     // Checks that the list of elements has the exact text content in order
     await expect(researchCollectionLabels).toHaveText(researchCollections);
+
+    // Verify that the labels are clickable links
+    const researchCollectionLinks = page.locator('#_pw-research-archives a.label-link');
+    await expect(researchCollectionLinks).toHaveCount(researchCollections.length);
   });
 
   test('has the correct main heading', async ({ page }) => {


### PR DESCRIPTION
Wraps research archive labels (e.g., years, categories) in anchor tags to improve usability by increasing the clickable area. Also verified with Playwright tests.

Changes:
- Wrap labels in <a> tags in 'research_archives.html'
- Add styles for 'a.label-link' in 'research.scss'
- Update Playwright test to verify clickable links

Fixes #1250

Preview URL: https://doradotdev--pr1251-drafts-off-mb503lhd.web.app/research/