### PR TITLE
feat(ai): add hover underline to insights links

### DIFF
--- a/hugo/themes/dora-2025/assets/scss/section.scss
+++ b/hugo/themes/dora-2025/assets/scss/section.scss
@@ -202,6 +202,10 @@
           text-decoration: none;
           color: var(--dora-primary-dark);
           font-weight: 500;
+
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
     }

--- a/test/playwright/tests/ai/ai-overview.spec.ts
+++ b/test/playwright/tests/ai/ai-overview.spec.ts
@@ -77,4 +77,12 @@ test.describe("AI Research Overview Page", () => {
   test("does not have the research archives tabs", async ({ page }) => {
     await expect(page.locator("tab_links")).not.toBeVisible();
   });
+
+  test("insights links have underline text-decoration on hover", async ({ page }) => {
+    const link = page.locator('.insights-list .insights-content ul li a').first();
+    await expect(link).toBeVisible();
+    await expect(link).toHaveCSS('text-decoration-line', 'none');
+    await link.hover();
+    await expect(link).toHaveCSS('text-decoration-line', 'underline');
+  });
 });


### PR DESCRIPTION
Adds a text-decoration: underline style to the insights links on the /ai page when hovered, to better indicate clickability.

Includes a regression test in Playwright.

Fixes #1253

Preview URL: https://doradotdev--pr1254-drafts-off-7d4bfb2l.web.app/ai/#generative-ai-insights