### PR TITLE
Add browser caching for playwright

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up node. # establish build cache
+      - name: Set up node.
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'


### PR DESCRIPTION
This PR uses GHA caching to cache browser downloads for playwright. 

It reduces build times by about 50 seconds.

Fixes #1264 