### PR TITLE
feat: add a summary to each item in the "DORA research archives" list.

### DIFF
--- a/hugo/content/ai/_index.md
+++ b/hugo/content/ai/_index.md
@@ -2,6 +2,7 @@
 title: "Artificial Intelligence"
 date: 2025-11-26
 draft: false
+archive_summary: "AI is fundamentally reshaping software delivery and organizational performance."
 ---
 
 {{< report_feature

--- a/hugo/content/research/2014/_index.md
+++ b/hugo/content/research/2014/_index.md
@@ -5,6 +5,7 @@ draft: false
 research_collection: "2014"
 type: research_archives
 layout: single
+archive_summary: "DevOps is a cultural shift, not just technical practices, that drives significant improvements in IT and organizational performance."
 ---
 <grid class="border_none" style="margin-top:1rem;">
 <item>

--- a/hugo/content/research/2015/_index.md
+++ b/hugo/content/research/2015/_index.md
@@ -5,6 +5,7 @@ draft: false
 research_collection: "2015"
 type: research_archives
 layout: single
+archive_summary: "High-performing IT organizations consistently outperform their counterparts in terms of four key software delivery metrics."
 ---
 
 <grid class="border_none" style="margin-top:1rem;">

--- a/hugo/content/research/2016/_index.md
+++ b/hugo/content/research/2016/_index.md
@@ -5,6 +5,7 @@ draft: false
 research_collection: "2016"
 type: research_archives
 layout: single
+archive_summary: "Integrating quality into every stage and adopting experimental product development drives higher performance."
 ---
 <grid class="border_none" style="margin-top:1rem;">
 <item>

--- a/hugo/content/research/2017/_index.md
+++ b/hugo/content/research/2017/_index.md
@@ -5,6 +5,7 @@ draft: false
 research_collection: "2017"
 type: research_archives
 layout: single
+archive_summary: "Transformational leadership plays a key role in fostering a culture of high performance."
 ---
 
 <grid class="border_none" style="margin-top:1rem;">

--- a/hugo/content/research/2018/_index.md
+++ b/hugo/content/research/2018/_index.md
@@ -7,6 +7,7 @@ type: research_archives
 layout: single
 tab_order: "0"
 tab_title: "Overview"
+archive_summary: 'Operational performance joins the metrics, and the "Elite" cluster is introduced to define the highest level of software delivery.'
 ---
 
 2018 saw the release of the first Accelerate State of DevOps Report independently published by DORA. [Read the 2018 report here]({{< relref "dora-report/" >}}).

--- a/hugo/content/research/2019/_index.md
+++ b/hugo/content/research/2019/_index.md
@@ -7,6 +7,7 @@ type: research_archives
 layout: single
 tab_order: "0"
 tab_title: "Overview"
+archive_summary: "Communities of practice outperform centers of excellence, while heavyweight change approval processes negatively impact performance."
 ---
 
 <div style="border:1px solid #ddd;">

--- a/hugo/content/research/2020/_index.md
+++ b/hugo/content/research/2020/_index.md
@@ -6,6 +6,7 @@ research_collection: "2020"
 # SEM and survey questions are included via template: templates/research_archives/single.html, if specified in front matter. The data for survey questions can be found at data/survey_questions.json
 type: research_archives
 layout: single
+archive_summary: "DevOps transformations deliver significant Return on Investment (ROI) across the entire organization."
 ---
 
 <grid class="border_none" style="margin-top:1rem;">

--- a/hugo/content/research/2021/_index.md
+++ b/hugo/content/research/2021/_index.md
@@ -7,6 +7,7 @@ type: research_archives
 layout: single
 tab_order: "0"
 tab_title: "Overview"
+archive_summary: "High-quality internal documentation is foundational for successfully implementing technical capabilities."
 ---
 
 In 2021, DORA did deep-dive investigations into security, reliability, documentation, and more. You can [read the 2021 report here]({{< relref "dora-report" >}}). Below are some of the analytical tools used in producing the report.
@@ -15,20 +16,20 @@ In 2021, DORA did deep-dive investigations into security, reliability, documenta
 
 {{< image src="dora-report/2021-dora-accelerate-state-of-devops-report.png" url="dora-report" float="right" width="18em" border="1px solid #eee" >}}
 
-#### The highest performers are growing and continue to raise the bar. 
-Elite performers now make up 26% of teams, and have decreased their lead times for changes to production. The industry continues to accelerate, and teams see meaningful benefits from doing so. 
+#### The highest performers are growing and continue to raise the bar.
+Elite performers now make up 26% of teams, and have decreased their lead times for changes to production. The industry continues to accelerate, and teams see meaningful benefits from doing so.
 
-#### SRE and DevOps are complementary philosophies. 
-Teams that leverage modern operations practices, outlined by our Site Reliability Engineering (SRE) friends, report higher operational performance. Teams that prioritize both delivery and operational excellence report the highest organizational performance. 
+#### SRE and DevOps are complementary philosophies.
+Teams that leverage modern operations practices, outlined by our Site Reliability Engineering (SRE) friends, report higher operational performance. Teams that prioritize both delivery and operational excellence report the highest organizational performance.
 
-#### More teams are leveraging the cloud and see significant benefits from doing so. 
+#### More teams are leveraging the cloud and see significant benefits from doing so.
 Teams continue to move workloads to the cloud and those that leverage all five capabilities of cloud see increases in software delivery and operational performance and organizational performance. Multi-cloud adoption is also on the rise so that teams can leverage the unique capabilities of each provider.
 
-#### A secure software supply chain is both essential and drives performance. 
-Given the significant increase in malicious attacks in recent years, it is even more pressing for organizations to shift from reactive practices to proactive and diagnostic measures. Teams that integrate security practices throughout their software supply chain to deliver software quickly, reliability, and safely. 
+#### A secure software supply chain is both essential and drives performance.
+Given the significant increase in malicious attacks in recent years, it is even more pressing for organizations to shift from reactive practices to proactive and diagnostic measures. Teams that integrate security practices throughout their software supply chain to deliver software quickly, reliability, and safely.
 
-#### Good documentation is foundational for successfully implementing capabilities. 
-For the first time, we measured the quality of internal documentation and practices that contribute to this quality. Teams with high quality documentation are better able to implement technical best practices and perform better as a whole. 
+#### Good documentation is foundational for successfully implementing capabilities.
+For the first time, we measured the quality of internal documentation and practices that contribute to this quality. Teams with high quality documentation are better able to implement technical best practices and perform better as a whole.
 
-#### A healthy team culture mitigates burnout during challenging circumstances. 
-Team culture makes a large difference to a team's ability to deliver software and meet or exceed their organizational goals. Inclusive teams with a generative culture experienced less burnout during the COVID-19 pandemic. 
+#### A healthy team culture mitigates burnout during challenging circumstances.
+Team culture makes a large difference to a team's ability to deliver software and meet or exceed their organizational goals. Inclusive teams with a generative culture experienced less burnout during the COVID-19 pandemic.

--- a/hugo/content/research/2022/_index.md
+++ b/hugo/content/research/2022/_index.md
@@ -7,6 +7,7 @@ type: research_archives
 tab_order: "0"
 tab_title: "Overview"
 layout: single
+archive_summary: "The biggest predictor of an organization’s application-development security practices is cultural, not technical."
 ---
 In 2022, DORA continued its investigation into software development and operations, and the capabilities which drive performance. This year's deep-dive investigations included security, reliability, and culture. You can [download the 2022 report here]({{< relref "dora-report" >}}).
 
@@ -19,7 +20,7 @@ High trust, low-blame cultures focused on performance were significantly more li
 
 #### The key variables that impact organizational performance tend to fall in the following categories:
 **Organizational and team culture**
-High-trust and low-blame cultures tend to have higher organizational performance. Similarly, organizations with teams that feel supported through funding and leadership sponsorships tend to have higher organizational performance. Team stability and positive perceptions about one’s team also tend to lead to higher levels of organizational performance. Lastly, the companies that offer flexible work arrangements are the companies that tend to see high levels of organizational performance. 
+High-trust and low-blame cultures tend to have higher organizational performance. Similarly, organizations with teams that feel supported through funding and leadership sponsorships tend to have higher organizational performance. Team stability and positive perceptions about one’s team also tend to lead to higher levels of organizational performance. Lastly, the companies that offer flexible work arrangements are the companies that tend to see high levels of organizational performance.
 
 **Reliability**
 Both the practices we associate with reliability engineering and the extent to which people report meeting their reliability expectations are powerful predictors of high levels of organizational performance.
@@ -30,7 +31,7 @@ Teams continue to move workloads to the cloud and those that leverage all five c
 #### Context matters
 DORA has long postulated that many of these effects depend on a team’s broader context. For example, a technical capability in one context could empower a team, but in another context, could have deleterious effects.
 
-Software delivery performance’s effect on organizational performance depends on operational performance (reliability), such that high software delivery performance is only beneficial to organizational performance when operational performance is also high. Implementing software supply chain security controls like those recommended by the SLSA framework has a positive effect on software delivery performance, but only when continuous integration is firmly established as a capability. 
+Software delivery performance’s effect on organizational performance depends on operational performance (reliability), such that high software delivery performance is only beneficial to organizational performance when operational performance is also high. Implementing software supply chain security controls like those recommended by the SLSA framework has a positive effect on software delivery performance, but only when continuous integration is firmly established as a capability.
 
 Technical capabilities build upon one another. Continuous delivery and version control amplify each other’s ability to promote high levels of software delivery performance. Combining continuous delivery, loosely coupled teams, version control, and continuous integration fosters software delivery performance that is greater than the sum of its parts.
 

--- a/hugo/content/research/2023/_index.md
+++ b/hugo/content/research/2023/_index.md
@@ -7,6 +7,7 @@ type: "research_archives"
 tab_order: "0"
 tab_title: "Overview"
 layout: single
+archive_summary: "User-centricity predicts 40% higher performance, while quality documentation amplifies the impact of technical capabilities."
 ---
 
 <object data="dora-report/2023-dora-report-infographic.svg" id="dora-core-model" type="image/svg+xml" style="width:100%;"></object>

--- a/hugo/content/research/2024/_index.md
+++ b/hugo/content/research/2024/_index.md
@@ -7,6 +7,7 @@ tab_order: "2"
 tab_title: "Overview"
 type: "research_archives"
 layout: single
+archive_summary: "Platform engineering and user-centricity drive success, while AI begins to reshape the software delivery landscape."
 comment: This file is also hosted at https://services.google.com/fh/files/misc/dora_one_pager_2024.pdf update both together. allisonpark@ can update the PDF at services.google.com using go/gumdrop.
 ---
 

--- a/hugo/content/research/2025/_index.md
+++ b/hugo/content/research/2025/_index.md
@@ -7,6 +7,7 @@ type: research_archives
 layout: single
 tab_order: "0"
 tab_title: "Overview"
+archive_summary: "AI acts as an amplifier, but the greatest returns come from focusing on the underlying sociotechnical systems."
 ---
 
 <object data="2025-dora-report-infographic.svg" id="dora-2025-infographic" type="image/svg+xml" class="responsive-svg"></object>

--- a/hugo/themes/dora-2025/assets/scss/research.scss
+++ b/hugo/themes/dora-2025/assets/scss/research.scss
@@ -214,12 +214,30 @@ tab_links {
                 &:hover {
                     text-decoration: underline;
                 }
+
+                @media (min-width: 1000px) {
+                    min-width: 16rem;
+                    display: inline-block; // Ensure width is respected
+                }
             }
 
             .label {
                 font-family: $font-google-sans;
                 font-size: 1.1rem;
                 font-weight: 500;
+                white-space: nowrap; // Prevent wrapping of label
+            }
+
+            .archive-summary {
+                display: none;
+                flex: 1;
+                margin: 0 2rem;
+                color: $color-text-medium;
+                // font-family: $font-roboto; // Inherited
+
+                @media (min-width: 1000px) {
+                    display: block;
+                }
             }
 
             a.button {

--- a/hugo/themes/dora-2025/layouts/partials/research_archives.html
+++ b/hugo/themes/dora-2025/layouts/partials/research_archives.html
@@ -1,57 +1,22 @@
 <span id="_pw-research-archives">
     <ul class="past-research-list">
+        {{ $links := slice
+        (dict "path" "/ai" "label" "Artificial Intelligence")
+        }}
+        {{ range seq 2025 -1 2014 }}
+        {{ $links = $links | append (dict "path" (printf "/research/%d" .) "label" (printf "%d" .)) }}
+        {{ end }}
+
+        {{ range $links }}
+        {{ $page := $.Site.GetPage .path }}
+        {{ if $page }}
         <li>
-            <a href='{{ relref . "/ai/" }}' class="label-link"><span class="label">Artificial Intelligence</span></a>
-            <a href='{{ relref . "/ai/" }}' class="button">View research</a>
+            <a href='{{ $page.RelPermalink }}' class="label-link"><span class="label">{{ .label }}</span></a>
+            {{ with $page.Params.archive_summary }}<span class="archive-summary">{{ . }}</span>{{ end }}
+            <a href='{{ $page.RelPermalink }}' class="button">View research</a>
         </li>
-        <li>
-            <a href='{{ relref . "/research/2025/" }}' class="label-link"><span class="label">2025</span></a>
-            <a href='{{ relref . "/research/2025/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2024/" }}' class="label-link"><span class="label">2024</span></a>
-            <a href='{{ relref . "/research/2024/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2023/" }}' class="label-link"><span class="label">2023</span></a>
-            <a href='{{ relref . "/research/2023/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2022/" }}' class="label-link"><span class="label">2022</span></a>
-            <a href='{{ relref . "/research/2022/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2021/" }}' class="label-link"><span class="label">2021</span></a>
-            <a href='{{ relref . "/research/2021/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2020/" }}' class="label-link"><span class="label">2020</span></a>
-            <a href='{{ relref . "/research/2020/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2019/" }}' class="label-link"><span class="label">2019</span></a>
-            <a href='{{ relref . "/research/2019/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2018/" }}' class="label-link"><span class="label">2018</span></a>
-            <a href='{{ relref . "/research/2018/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2017/" }}' class="label-link"><span class="label">2017</span></a>
-            <a href='{{ relref . "/research/2017/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2016/" }}' class="label-link"><span class="label">2016</span></a>
-            <a href='{{ relref . "/research/2016/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2015/" }}' class="label-link"><span class="label">2015</span></a>
-            <a href='{{ relref . "/research/2015/" }}' class="button">View research</a>
-        </li>
-        <li>
-            <a href='{{ relref . "/research/2014/" }}' class="label-link"><span class="label">2014</span></a>
-            <a href='{{ relref . "/research/2014/" }}' class="button">View research</a>
-        </li>
+        {{ end }}
+        {{ end }}
     </ul>
     <h4 id="publications-legacy" style="margin-top: 3rem;">Additional Publications</h4>
     <ul class="past-research-list">


### PR DESCRIPTION
Adds a brief summary to each item in the research archives list on the research home page. These summaries provide a quick overview of the focus for each year or section.

Changes include:
- Added `archive_summary` to the front matter of all research archive pages (AI, 2014-2025).
- Refactored `research_archives.html` to dynamically generate the list and display the summary.
- Updated `research.scss` to:
  - Hide summaries on mobile and narrow desktop screens (< 1000px) to prevent horizontal scrolling.
  - Show summaries on wider screens.
  - Enforce a fixed width for labels on wide screens to ensure vertical alignment of the summary text.

Preview URL: https://doradotdev--pr1269-drafts-on-b5f96b42.web.app/research/#dora_research_archives