### PR TITLE
Add "How customization supports developer engagement" research insight

### DIFF
--- a/hugo/content/insights/ai-as-a-tutor/index.md
+++ b/hugo/content/insights/ai-as-a-tutor/index.md
@@ -18,7 +18,7 @@ guides:
     6: {name: "Nathen Harvey", url: "https://www.linkedin.com/in/nathen/"}
 headline: "AI as a tutor"
 type: "insights"
-tags: ["AI", "Education", "Learning"]
+tags: ["AI", "Education", "Learning", "UC Berkeley"]
 summary: "While critics worry students use AI to cheat, our research reveals something different: students are using AI to learn. At UC Berkeley, many students in technical fields are using AI to teach them rather than do for them: AI was a supplement to the role of professor, TA, or tutor."
 ---
 

--- a/hugo/content/insights/customization-supports-developer-engagement/index.md
+++ b/hugo/content/insights/customization-supports-developer-engagement/index.md
@@ -1,0 +1,45 @@
+---
+title: "How customization supports developer engagement"
+date: 2025-09-23
+updated: 2025-09-23
+draft: false
+authors:
+    1: {name: "Edward Fraser", url: "https://www.linkedin.com/in/edward-fraser/"}
+    2: {name: "Jessie Deng", url: "https://www.linkedin.com/in/jwdeng/"}
+    3: {name: "Eileen Thai", url: "https://www.linkedin.com/in/eileen-thai/"}
+guides:
+    1: {name: "Steve Fadden", url: "https://www.linkedin.com/in/stevefadden/"}
+    2: {name: "John Chuang", url: "https://www.linkedin.com/in/johncichuang/"}
+type: "insights"
+tags: ["AI", "Education", "Learning", "Developer Experience", "UC Berkeley"]
+layout: single
+summary: "While AI coding assistants excel at mechanical tasks, research with UC Berkeley students reveals they can introduce friction and cognitive load during complex, interpretive work. By customizing AI tools to align with specific tasks and preferences, developers can reduce this friction and create a more efficient, satisfying development experience."
+---
+
+<p class="research-note">
+This DORA Insight is an excerpt from the 2025 DORA report, <a href="/research/2025/dora-report/">State of AI-Assisted Software Development</a>.
+</p>
+
+## What we studied
+
+As AI assistants become more common in development work, a graduate research team at UC Berkeley studied how student developers use AI-powered integrated development environments (IDEs) in practice. Using eye-tracking data and interviews, the team observed how Python developers with between one and five years of experience tackled two short tasks: one involving an unfamiliar library, and another requiring interpretation of a cryptic function.
+
+By applying insights from this study, developers of all experience levels may find ways of working with AI coding assistants that are more attuned to their needs.
+
+## Customization as a solution
+
+To reduce friction and better support focused work, developers and teams can customize their AI tools. Most IDEs now offer features like toggling inline suggestions, enabling “on-demand only” modes, or adjusting the style and structure of suggestions.
+
+Repository-level config files and linked documentation can help AI assistants follow established protocols. Experimenting with these settings can align AI behavior with the cognitive demands of different tasks, helping to reduce disruption and increase the usefulness of AI assistants.
+
+## When AI gets in the way
+
+While AI coding assistants are designed to save time and reduce effort, a study conducted at UC Berkeley found that they can also introduce friction in some tasks. For example, student developers embraced AI when handling mechanical tasks like writing boilerplate and installing packages, but when deeper understanding was needed, such as interpreting complex code, those same student developers largely ignored AI suggestions.
+
+Eye-tracking revealed less than 1% visual attention on AI chat during interpretive tasks, compared to nearly 19% during the more mechanical ones. The students in this study often chose to complete tasks manually to retain control and comprehension, even ignoring accurate, time-saving suggestions.
+
+## Takeaway for teams
+
+To get the most out of AI coding assistants, developers and teams should invest in customization. This study showed that AI may disrupt interpretive tasks by adding cognitive load, especially when developers are trying to make sense of unfamiliar code.
+
+The key is aligning AI support with the nature of the task and preferences of the developer. Tuning your setup can transform AI from a source of friction into a more efficient and satisfying development experience.

--- a/hugo/content/insights/managing-ai-dependency/index.md
+++ b/hugo/content/insights/managing-ai-dependency/index.md
@@ -17,7 +17,7 @@ guides:
     6: {name: "Becky Sohn", url: "https://www.linkedin.com/in/rebeccasohn/"}
 headline: "Managing AI dependency: How students are establishing guardrails with AI"
 type: "insights"
-tags: ["AI", "Education", "Learning"]
+tags: ["AI", "Education", "Learning", "UC Berkeley"]
 summary: "While AI makes challenging projects feel more accessible, it also sparks anxiety about becoming too dependent. Our research with UC Berkeley students found that students are establishing guardrails for themselves, treating AI as a support tool rather than a replacement for deep understanding."
 ---
 

--- a/test/playwright/tests/insights/customization-supports-developer-engagement.spec.ts
+++ b/test/playwright/tests/insights/customization-supports-developer-engagement.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { LAST_UPDATED_DATE_REGEX } from '../constants';
+import { verifyAuthors } from '../verify-authors';
+
+test.describe(`How customization supports developer engagement insight`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/insights/customization-supports-developer-engagement/');
+  });
+
+  test('has the correct title.', async ({ page }) => {
+    await expect(page).toHaveTitle('DORA | How customization supports developer engagement');
+  });
+
+  test('has the correct header.', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'How customization supports developer engagement' })).toBeVisible();
+  });
+
+  test('displays its last updated date', async ({ page }) => {
+    await expect(page.locator('.updated')).toContainText(LAST_UPDATED_DATE_REGEX);
+  });
+
+  test('displays authors.', async ({ page }) => {
+    await verifyAuthors(page);
+  });
+});


### PR DESCRIPTION
Adds the new research insight article: "How customization supports developer engagement," featuring findings from UC Berkeley researchers.

* Styles the excerpt attribution on the new page using the .research-note CSS class 
* Add new "UC Berkeley" tag for Insights
  * Add to "AI as a tutor," "Managing AI dependency," and this new Insight
* Adds a Playwright test for the new Insight

Preview URLs:
* https://doradotdev--pr1313-drafts-off-xqi4e98f.web.app/insights/ - Includes the insight, "How customization supports developer engagement"
* https://doradotdev--pr1313-drafts-off-xqi4e98f.web.app/insights/customization-supports-developer-engagement/
* https://doradotdev--pr1313-drafts-off-xqi4e98f.web.app/insights/tags/uc-berkeley/ - includes the three insights done in collaboration with UC Berkeley. 