### PR TITLE
Remove 2018 research overview page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -415,6 +415,16 @@
           "type": 301
         },
         {
+          "source": "/research/2018",
+          "destination": "/research/2018/dora-report/",
+          "type": 301
+        },
+        {
+          "source": "/research/2018/",
+          "destination": "/research/2018/dora-report/",
+          "type": 301
+        },
+        {
           "source": "/publications/pdf/state-of-devops-2019.pdf",
           "destination": "/research/2019/dora-report/2019-dora-accelerate-state-of-devops-report.pdf",
           "type": 301

--- a/hugo/content/research/2018/_index.md
+++ b/hugo/content/research/2018/_index.md
@@ -5,7 +5,6 @@ draft: false
 research_collection: "2018"
 type: research_archives
 layout: single
-tab_order: "0"
 tab_title: "Overview"
 archive_summary: 'Operational performance joins the metrics, and the "Elite" cluster is introduced to define the highest level of software delivery.'
 ---

--- a/hugo/content/research/2018/dora-report/index.md
+++ b/hugo/content/research/2018/dora-report/index.md
@@ -3,7 +3,7 @@ title: "Accelerate State of DevOps Report 2018"
 date: 2018-09-01
 draft: false
 type: research_archives
-tab_order: "2"
+tab_order: "1"
 tab_title: "DORA Report"
 research_collection: "2018"
 ---

--- a/hugo/content/research/2018/questions.md
+++ b/hugo/content/research/2018/questions.md
@@ -3,7 +3,7 @@ title: "DORA Research Questions"
 date: 2018-09-01
 research_collection: "2018"
 draft: false
-tab_order: "3"
+tab_order: "2"
 tab_title: "Questions"
 type: "research_archives/questions"
 ---

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -191,6 +191,6 @@
 /research/shared/dora-report-2025/2025-state-of-ai-assisted-software-development-report-thumb.png,/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report-thumb.png,301
 /research/shared/dora-report-2025/2025-state-of-ai-assisted-software-development-report.png,/research/2025/dora-report/2025-state-of-ai-assisted-software-development-report.png,301
 /ai/roi/,/ai/roi/report/,302
-/ai/roi,/ai/roi/report/,302
-/roi-ai-report/,/ai/roi/report/,301
 /roi-ai-report,/ai/roi/report/,301
+/research/2018/,/research/2018/dora-report/,301
+/research/2018,/research/2018/dora-report/,301


### PR DESCRIPTION
Create a redirect to the 2018 report page.

Fixes #1042

Preview URLs:
* https://doradotdev--pr1376-drafts-off-42klrewe.web.app/research/2018
* https://doradotdev--pr1376-drafts-off-42klrewe.web.app/research/2018/