### PR TITLE
Fix search for ROI report

### DIFF
--- a/hugo/content/search/search.js
+++ b/hugo/content/search/search.js
@@ -97,7 +97,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
                 link: '/ai/gen-ai-report/',
                 thumbnail_url: '/img/sodr_thumbnails/gen-ai-report.png',
             },
-            'dora-roi-of-ai-assisted-software-development-2026': {
+            '2026 ROI of AI-assisted Software Development': {
                 title: 'ROI of AI-assisted Software Development',
                 link: '/ai/roi/report/',
                 thumbnail_url: '/img/sodr_thumbnails/roi-of-ai-assisted-software.png',

--- a/test/playwright/tests/search/pdf-results.spec.ts
+++ b/test/playwright/tests/search/pdf-results.spec.ts
@@ -46,13 +46,12 @@ test.describe('PDF search results', () => {
       expectedLink: '/dora-report-2020',
       expectedImg: '/img/sodr_thumbnails/2020.png'
     },
-    // TODO: uncomment once the report has been added to the search index
-    // {
-    //   searchQuery: 'ROI of AI-assisted Software Development',
-    //   expectedTitle: '2026 ROI of AI-assisted Software Development',
-    //   expectedLink: '/ai/roi/report/',
-    //   expectedImg: '/img/sodr_thumbnails/roi-of-ai-assisted-software.png'
-    // },
+    {
+      searchQuery: 'ROI of AI-assisted Software Development',
+      expectedTitle: 'ROI of AI-assisted Software Development',
+      expectedLink: '/ai/roi/report/',
+      expectedImg: '/img/sodr_thumbnails/roi-of-ai-assisted-software.png'
+    },
   ];
 
   for (const report of reports) {


### PR DESCRIPTION
Aligned the title between the PDF and the javascript.

Also uncomments the tests for the ROI report now that it's in the search index.

Preview URL: https://doradotdev--pr1395-drafts-off-vq6f07g2.web.app/search/?q=J-curve