### PR TITLE
Link to the DORA Award nominations from the home page

### DIFF
--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -66,9 +66,9 @@ bannerSubtitle: "DORA is the largest and longest running research program of its
     img_src="/img/homepage/snipes/award.png"
     eyebrow="Awards"
     headline="Google Cloud DORA Awards"
-    url="/awards"
+    url="https://cloud.google.com/awards/dora"
   >}}
-    Learn about the accomplishments of all the 2025 Google Cloud DORA Award winners!
+    Celebrate your team's remarkable success! Nominations for the 2026 Google Cloud DORA Awards are now open.
     {{< /homepage/snipe >}}
 
 {{< homepage/snipe-wrapper mode="end" >}}


### PR DESCRIPTION
Updates the link to the 2026 award nominations instead of /awards, the 2025 winners.


Preview: https://doradotdev--pr1400-drafts-off-l7v3nsks.web.app/

The DORA Awards should link to cloud.google.com/awards/dora