### PR TITLE
Add redirect for 2024 Quick Check to main Quick Check tool

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -110,6 +110,11 @@
           "type": 301
         },
         {
+          "source": "/quickcheck-2024",
+          "destination": "/quickcheck/",
+          "type": 301
+        },
+        {
           "source": "/performance.html**",
           "destination": "/quickcheck/",
           "type": 301

--- a/svelte/migrate-to-workspaces/03-remove-2024-quickcheck.md
+++ b/svelte/migrate-to-workspaces/03-remove-2024-quickcheck.md
@@ -1,0 +1,6 @@
+# Phase 1 - Add redirects
+
+/quickcheck-2024 and any query parameters automatically redirect to /quickcheck with the same query parameters. This makes the 2024 quick check inaccessible.
+
+Redirect tests are updated to verify the changes.
+

--- a/test/playwright/tests/quickcheck2024.spec.ts
+++ b/test/playwright/tests/quickcheck2024.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('quick check test', async ({ page }) => {
+test.skip('quick check test', async ({ page }) => {
     await page.goto('/quickcheck-2024');
     // await page.getByRole('link', { name: 'Quick Check', exact: true }).first().click();
     await page.click('input[name="leadtime"][value="6"]')
@@ -35,7 +35,7 @@ test('quick check test', async ({ page }) => {
     await expect(page.locator('.score_text.culture')).toContainText('10.0');
 });
 
-test('quick check org size comparison', async ({ page }) => {
+test.skip('quick check org size comparison', async ({ page }) => {
     await page.goto('/quickcheck-2024/?comp=size');
     await page.getByRole('group', { name: 'For the primary application or service you work on, what is your lead time for' }).getByLabel('Less than one hour').check();
     await page.getByLabel('On demand (multiple deploys').check();

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -209,4 +209,6 @@
 /research/2018,/research/2018/dora-report/,301
 /youtube,https://www.youtube.com/@dora-dev,302
 /youtube/,https://www.youtube.com/@dora-dev,302
-
+/quickcheck-2024,/quickcheck/,301
+/quickcheck-2024/,/quickcheck/,301
+/quickcheck-2024/?leadtime=3&deployfreq=2&changefailure=25&failurerecovery=2&v=2024&industry=all&ci=22233&arch=333444&culture=555554&step=priorities,/quickcheck/?leadtime=3&deployfreq=2&changefailure=25&failurerecovery=2&v=2024&industry=all&ci=22233&arch=333444&culture=555554&step=priorities,301


### PR DESCRIPTION
Redirects `/quickcheck-2024` to `/quickcheck/` via a 301 permanent redirect in `firebase.json`. This ensures users accessing the legacy path are routed to the current version of the tool.

- Updated `firebase.json` with the new redirect rule.
- Updated `test/redirects/redirects.csv` to include test cases for the new legacy redirects.
- Added documentation for this phase of the migration

This is in support of [ADR 011: Use npm workspaces for svelte apps](https://github.com/dora-team/dora.dev/blob/main/docs/adrs/011-use-npm-workspaces-for-svelte-apps.md).

Supports: #1411


Preview URLs:
* https://doradotdev--pr1413-drafts-off-fwxpgn1k.web.app/quickcheck-2024
* https://doradotdev--pr1413-drafts-off-fwxpgn1k.web.app/quickcheck-2024/?leadtime=3&deployfreq=2&changefailure=25&failurerecovery=2&v=2024&industry=all&ci=22233&arch=333444&culture=555554&step=priorities 