### PR TITLE
Fix mobile horizontal container overflow in research archives

### DIFF
--- a/hugo/themes/dora-2025/assets/scss/research.scss
+++ b/hugo/themes/dora-2025/assets/scss/research.scss
@@ -207,6 +207,12 @@ tab_links {
             padding: 1.5rem 0;
             border-bottom: 1px solid var(--grey-30);
 
+            @include media-medium {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 1rem;
+            }
+
             a.label-link {
                 text-decoration: none;
                 color: inherit;
@@ -226,6 +232,10 @@ tab_links {
                 font-size: 1.1rem;
                 font-weight: 500;
                 white-space: nowrap; // Prevent wrapping of label
+
+                @include media-medium {
+                    white-space: normal;
+                }
             }
 
             a.archive-summary-link {

--- a/test/playwright/tests/research/index.spec.ts
+++ b/test/playwright/tests/research/index.spec.ts
@@ -36,4 +36,43 @@ test.describe('Research home page', () => {
     const coreModelAnchor = page.locator('#core-model');
     await expect(coreModelAnchor).toBeAttached();
   });
+
+  test.describe('Mobile layout', () => {
+    test.use({ viewport: { width: 375, height: 667 } });
+
+    test('additional publications do not overflow their list item container horizontally', async ({ page }) => {
+      await page.goto('/research/');
+      
+      const pastResearchSection = page.locator('#_pw-research-archives');
+      await expect(pastResearchSection).toBeVisible();
+      
+      const listItems = pastResearchSection.locator('ul.past-research-list li');
+      const count = await listItems.count();
+      expect(count).toBeGreaterThan(0);
+      
+      for (let i = 0; i < count; i++) {
+        const li = listItems.nth(i);
+        const labelLink = li.locator('a.label-link');
+        const button = li.locator('a.button');
+        
+        const liBox = await li.boundingBox();
+        const labelBox = await labelLink.boundingBox();
+        const buttonBox = await button.boundingBox();
+        
+        expect(liBox).not.toBeNull();
+        expect(labelBox).not.toBeNull();
+        expect(buttonBox).not.toBeNull();
+        
+        const containerRight = liBox!.x + liBox!.width;
+        const labelRight = labelBox!.x + labelBox!.width;
+        const buttonRight = buttonBox!.x + buttonBox!.width;
+        
+        // Assert that the label fits horizontally within the list item container
+        expect(labelRight).toBeLessThanOrEqual(containerRight + 1);
+        // Assert that the button fits horizontally within the list item container
+        expect(buttonRight).toBeLessThanOrEqual(containerRight + 1);
+      }
+    });
+  });
 });
+


### PR DESCRIPTION
Updates the layout and adds a test to catch regressions.

Fixes #1422


Preview URL: https://doradotdev--pr1424-drafts-off-gtpc4slh.web.app/research