### PR TITLE
Downgrade node on preview builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Set up node.
         uses: actions/setup-node@v6
         with:
-          node-version: '22.x'  # pin to v22 b/c v24 is causing build issues (https://github.com/dora-team/dora.dev/pull/1431)
+          # pin to v22 b/c v24 is causing build issues (https://github.com/dora-team/dora.dev/pull/1431)
+          node-version: '22.x'
 
       - name: Restore cache - playwright binaries
         uses: actions/cache/restore@v5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Set up node.
         uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '22.x'  # pin to v22 b/c v24 is causing build issues (https://github.com/dora-team/dora.dev/pull/1431)
 
       - name: Restore cache - playwright binaries
         uses: actions/cache/restore@v5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Set up node.
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: Restore cache - playwright binaries
         uses: actions/cache/restore@v5
@@ -148,7 +148,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '22.x'
       - name: Install dependencies
         run: npm ci --registry=https://registry.npmjs.org/
       - name: Run redirect tests


### PR DESCRIPTION
From 24.x to 22.x

We are running into issues with GHA builds hanging and downgrading to 22.x seems to solve these issues.