### PR TITLE
Only install chromium for playwright

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: always() && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
 
       - name: Save cache - playwright binaries
         if: always() && steps.playwright-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
The other headless browsers aren't used or required.

This should reduce the build's footprint on disk and may speed up the builds.