### PR TITLE
Rename 'cloud-infrastructure' capability to 'flexible-infrastructure'

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -80,6 +80,11 @@
           "type": 301
         },
         {
+          "source": "/capabilities/cloud-infrastructure",
+          "destination": "/capabilities/flexible-infrastructure/",
+          "type": 301
+        },
+        {
           "source": "/concepts/wellbeing",
           "destination": "/capabilities/well-being/",
           "type": 302

--- a/hugo/content/capabilities/cloud-infrastructure/index.md
+++ b/hugo/content/capabilities/cloud-infrastructure/index.md
@@ -5,7 +5,7 @@ category: fast flow
 draft: false
 slug: flexible-infrastructure
 aliases:
-    - cloud-infrastructure
+    - /capabilities/cloud-infrastructure/
 core: true
 updated: 2026-01-12
 headline: "Find out how to manage cloud infrastructure effectively so you can achieve higher levels of agility, availability, and cost visibility."

--- a/hugo/content/capabilities/flexible-infrastructure/index.md
+++ b/hugo/content/capabilities/flexible-infrastructure/index.md
@@ -3,7 +3,6 @@ title: "Flexible infrastructure"
 date: 2023-03-27T09:48:50+01:00
 category: fast flow
 draft: false
-slug: flexible-infrastructure
 aliases:
     - /capabilities/cloud-infrastructure/
 core: true

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -212,3 +212,5 @@
 /quickcheck-2024,/quickcheck/,301
 /quickcheck-2024/,/quickcheck/,301
 /quickcheck-2024/?leadtime=3&deployfreq=2&changefailure=25&failurerecovery=2&v=2024&industry=all&ci=22233&arch=333444&culture=555554&step=priorities,/quickcheck/?leadtime=3&deployfreq=2&changefailure=25&failurerecovery=2&v=2024&industry=all&ci=22233&arch=333444&culture=555554&step=priorities,301
+/capabilities/cloud-infrastructure,/capabilities/flexible-infrastructure/,301
+/capabilities/cloud-infrastructure/,/capabilities/flexible-infrastructure/,301


### PR DESCRIPTION
Renames the Cloud Infrastructure capability to Flexible Infrastructure across the site, updating paths, setting up necessary redirects, and adding automated redirect tests.

* rename the capability's directory
* remove redundant front matter (`slug`)
* update alias for the page
* adds a firebase redirect and tests to validate the redirect

Preview URL: https://doradotdev--pr1435-drafts-off-j0m4752k.web.app/capabilities/cloud-infrastructure/