### PR TITLE
docs: add dora.community to resources websites list (closes #1438)

### DIFF
--- a/hugo/content/resources/_index.md
+++ b/hugo/content/resources/_index.md
@@ -123,4 +123,14 @@ Each of these tools will help your team collect and visualize <a href="/guides/d
         </p>
         </content>
     </item>
+    <item>
+        <h3>dora.community</h3>
+        <content>
+        <p>
+            Join the DORA Community to connect with other practitioners, ask questions, share experiences, and stay up to date with the latest DORA research and events.
+            <br>
+            <a href="https://dora.community/" target="_blank">dora.community</a>
+        </p>
+        </content>
+    </item>
 </grid>


### PR DESCRIPTION
## What

Add dora.community to the Websites section on the Resources page.

## Changes

- Add new item entry under Websites in hugo/content/resources/_index.md

## Checklist
- [x] Minimal change
- [x] No broken links
- [x] Matches existing website entry format
