### PR TITLE
Upgrade hugo to v0.163.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.147.9'
+          hugo-version: '0.163.2'
           extended: true
       - name: Build Svelte components
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.147.9'
+          hugo-version: '0.163.2'
           extended: true
       - name: Build Svelte components
         run: |
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.147.9'
+          hugo-version: '0.163.2'
           extended: true
       - name: Build Svelte components
         run: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ## Hugo
 The following development with Hugo will be sufficient for most of the DORA.dev website development efforts.
-To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (recommended version: [v0.147.9](https://github.com/gohugoio/hugo/releases/tag/v0.147.9)).
+To build and preview the site locally, you'll need [hugo](https://gohugo.io/) (recommended version: [v0.163.2](https://github.com/gohugoio/hugo/releases/tag/v0.163.2)).
 
 - The recommended command to start the local hugo server is `hugo serve -D -s hugo --disableFastRender --logLevel debug --watch`.
   - This will render and live-reload all pages, including drafts. _To suppress rendering of drafts, omit the `-D` flag._

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://dora.dev/"
-languageCode = "en-us"
+locale = "en-us"
 theme = "dora-2025"
 rssLimit = 10
 ignoreFiles = "README.md"
@@ -28,7 +28,7 @@ ignoreFiles = "README.md"
   priority = 0.5
 
 [[cascade]]
-  [cascade._target]
+  [cascade.target]
     path = "**/docs"
   [cascade._build]
     render = "never"

--- a/hugo/themes/dora-2025/layouts/partials/survey_questions.html
+++ b/hugo/themes/dora-2025/layouts/partials/survey_questions.html
@@ -20,7 +20,7 @@
   {{ else }}
   <h4>Responses to the following questions were used in the analysis published in the <a href="/research/{{ $researchCollectionTitle | urlize }}/dora-report/">{{ $researchCollectionTitle }} Accelerate State of DevOps Report</a>.</h4>
   {{ end }}
-  {{ with index .Site.Data.survey_questions $dataLookupKey }}
+  {{ with index hugo.Data.survey_questions $dataLookupKey }}
   {{ range sort .categories "heading" }}
   <h3 id="{{ .heading | anchorize }}">{{ .heading }}</h3>
   {{ if .description }}<p>{{ .description }}</p>{{ end }}


### PR DESCRIPTION
Address deprecation warnings:

* `cascade._target`
  * Hugo uses the `cascade` block to apply front matter settings to a set of pages matching a specific path pattern. `_target` was used to define this match query but was deprecated in Hugo v0.156.0. In `config.toml`, change `cascade._target` to `cascade.target`.

* `languageCode`
  * `languageCode` was deprecated in Hugo v0.158.0 in favor of `locale` to adopt industry-standard localization terminology. In `config.toml`, change `languageCode = "en-us"` to `locale = "en-us"`.

* `.Site.Data`
  * `.Site.Data` was used to pull structured data from files in the `data/` folder (such as `survey_questions`). In Hugo v0.156.0, this was deprecated in favor of the global `hugo.Data` function/namespace. This was done to decouple data queries from the page context (`.Site`), making data lookups cleaner and more performant. In `survey_questions.html`, replace `{{ with index .Site.Data.survey_questions $dataLookupKey }}` with `{{ with index hugo.Data.survey_questions $dataLookupKey }}`.