### PR TITLE
Bypass GFE connection drops during Firebase deploys (#1459)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Deploy to Firebase
         id: deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          NODE_OPTIONS: "--require ${{ github.workspace }}/.github/workflows/disable-fetch.js --dns-result-order=ipv4first"
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           projectId: ${{ vars.GOOGLE_CLOUD_PROJECT }}

--- a/.github/workflows/disable-fetch.js
+++ b/.github/workflows/disable-fetch.js
@@ -1,0 +1,31 @@
+// This is a workaround to prevent the issue from [$1459](https://github.com/dora-team/dora.dev/issues/1459)
+//
+// TODO:
+// Keep an eye on Node.js and `undici` updates. Once Node's global `fetch` handles connection reuse
+// timeouts and GFE Keep-Alive headers more robustly, you can remove the `.github/workflows/disable-fetch.js`
+// workaround and return to standard Node defaults.
+
+
+const http = require('http');
+
+// 1. Disable the global fetch API to force fallback to native http/https modules.
+global.fetch = undefined;
+global.Request = undefined;
+global.Response = undefined;
+global.Headers = undefined;
+
+// 2. Safely force keepAlive: false on all http/https agents by defining
+// a read-only accessor property on http.Agent.prototype. This preserves
+// the class hierarchy and "instanceof" checks perfectly while disabling Keep-Alive.
+Object.defineProperty(http.Agent.prototype, 'keepAlive', {
+  get() {
+    return false;
+  },
+  set(val) {
+    // Do nothing to ignore any attempts to enable keepAlive
+  },
+  configurable: true,
+  enumerable: true
+});
+
+console.log("🔒 Global fetch disabled & Keep-Alive disabled safely on all agents.");

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Deploy to Firebase
         id: deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          NODE_OPTIONS: "--require ${{ github.workspace }}/.github/workflows/disable-fetch.js --dns-result-order=ipv4first"
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.SERVICE_ACCOUNT }}
@@ -78,6 +80,8 @@ jobs:
       - name: Deploy to Firebase
         id: deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
+        env:
+          NODE_OPTIONS: "--require ${{ github.workspace }}/.github/workflows/disable-fetch.js --dns-result-order=ipv4first"
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.SERVICE_ACCOUNT }}


### PR DESCRIPTION
Resolves the persistent `Premature close` network socket errors during Google OAuth/STS token exchange in the GitHub Actions runner environment.

### Why:

During troubleshooting of issue #1459, we isolated a protocol-level mismatch on the runner:

1. Low-level diagnostics showed that small GETs and large 2KB POST requests succeeded perfectly when using `curl` because it negotiates and utilizes HTTP/2.
2. Node.js HTTP clients (both `fetch`/`undici` and the native `https` module) failed consistently with `Premature close` because they communicate over HTTP/1.1 by default.
3. In the runner's virtualized cloud network, HTTP/1.1 Keep-Alive connections to Google's Front End (GFE) API gateways were being terminated abruptly by the server during socket reuse (Keep-Alive timeouts).
4. Since the official `action-hosting-deploy` action runs under Node.js, it consistently crashed during the token exchange step.

### How:

We resolved this by implementing a surgical, zero-dependency workaround:

1. Added `.github/workflows/disable-fetch.js` to:
   - Disable Node's global `fetch` API (forcing a fallback to the stable, native HTTPS module).
   - Monkey-patch `http.Agent.prototype.keepAlive` using a safe prototype accessor property (getter/setter). This forces `keepAlive: false` globally across the entire Node process for all HTTP/HTTPS requests without breaking class hierarchy or `instanceof` checks (which would otherwise cause `npm` protocol errors).
2. Preloaded the script in `.github/workflows/preview.yml` (PR previews) and `.github/workflows/deploy.yml` (production deploys) via Node's standard `NODE_OPTIONS` environment variable.
3. This forces every request to use a fresh TCP connection and close it immediately upon completion, completely bypassing the socket recycling bugs.

This keeps your existing deployment pipeline, secrets, and workflows intact while immediately restoring stability across all preview and production deploys.

Fixes #1459