### PR TITLE
feat: redirect /reports to /research/publications/

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -70,6 +70,11 @@
           "type": 301
         },
         {
+          "source": "/reports",
+          "destination": "/research/publications/",
+          "type": 301
+        },
+        {
           "source": "/publications/errata",
           "destination": "/research/errata/",
           "type": 301

--- a/test/redirects/redirects.csv
+++ b/test/redirects/redirects.csv
@@ -155,6 +155,8 @@
 /research/ai/ai-capabilities-model/,/ai/capabilities-model/report/,302
 /publications/,/research/publications/,301
 /publications,/research/publications/,301
+/reports/,/research/publications/,301
+/reports,/research/publications/,301
 /publications/errata/,/research/errata/,301
 /publications/errata,/research/errata/,301
 /research/shared/ai-capabilities-model-report/2025-dora-ai-capabilities-model-report.png,/ai/capabilities-model/report/2025-dora-ai-capabilities-model-report.png,301


### PR DESCRIPTION
Adds the `/reports` convenience redirect requested in the issue.

Placed directly next to the existing `/publications` entry in `firebase.json`, since it is the same destination and the same intent — a short URL people are likely to type or share:

```json
{
  "source": "/publications",
  "destination": "/research/publications/",
  "type": 301
},
{
  "source": "/reports",
  "destination": "/research/publications/",
  "type": 301
},
```

Used `301` to match `/publications`. The `302` entries in this file look like they are for temporary or still-moving pages, which is not the case here — happy to switch if you'd rather keep convenience links non-permanent.

Verified the file still parses as valid JSON (120 redirects) and that `/reports` was not already defined as a source anywhere.

Closes #1476